### PR TITLE
Test Plan: Tool Calling Metadata Integration (v1.0.0)

### DIFF
--- a/tool_calling_model_catalog/README.md
+++ b/tool_calling_model_catalog/README.md
@@ -1,0 +1,19 @@
+# Tool Calling Model Catalog
+
+Integration of validated Tool Calling metadata into the RHOAI Model Catalog (Dev Preview, RHOAI 3.4).
+
+## References
+
+- **Strategy**: [RHAISTRAT-1262](https://redhat.atlassian.net/browse/RHAISTRAT-1262)
+- **Feature Refinement**: [Google Doc](https://docs.google.com/document/d/1XaK-rZPZEexUrrIMkyLXzjQJYY-rKATdkEPE_NRTz5I/edit)
+- **Release Notes**: [Google Doc](https://docs.google.com/document/d/1LYXSH8OsTy8SMwrq2Y3g5kjMqp09Moy1cAYBoZ4fD-k/edit)
+
+## Test Plan
+
+- [TestPlan.md](TestPlan.md) -- Full test plan for the feature
+
+## Test Cases
+
+- [Test Case Index](test_cases/INDEX.md) -- 42 test cases (P0: 19, P1: 18, P2: 5)
+
+Automated tests will be implemented in the `test_cases/` directory following the test plan structure.

--- a/tool_calling_model_catalog/TestPlan.md
+++ b/tool_calling_model_catalog/TestPlan.md
@@ -1,0 +1,300 @@
+---
+feature: tool_calling_model_catalog
+strat_key: RHAISTRAT-1262
+version: 1.0.0
+status: In Review
+author: RHOAI AI Hub
+additional_docs:
+- https://docs.google.com/document/d/1XaK-rZPZEexUrrIMkyLXzjQJYY-rKATdkEPE_NRTz5I/edit
+- https://docs.google.com/document/d/1LYXSH8OsTy8SMwrq2Y3g5kjMqp09Moy1cAYBoZ4fD-k/edit
+last_updated: '2026-04-13'
+reviewers: []
+---
+# Tool Calling Model Catalog Test Plan
+**RHOAI AI Hub -- Tool Calling Metadata Integration Testing**
+
+**Strategy**: [RHAISTRAT-1262](https://redhat.atlassian.net/browse/RHAISTRAT-1262)
+
+---
+
+## 1. Executive Summary
+
+### 1.1 Purpose
+
+This test plan covers the integration of validated Tool Calling metadata into the RHOAI Model Catalog (Dev Preview, RHOAI 3.4). The feature extends the Model Catalog schema with tool-calling-specific fields (such as `tool_calling_supported`, `required_cli_args`, `chat_template_path`, and `tool_call_parser`), exposes this metadata via the BFF API for the RHOAI Serving Wizard, and adds UI capabilities for filtering and displaying tool-calling information on modelcards.
+
+The goal is to establish the Model Catalog as the single source of truth for tool-calling-enabled models, replacing hardcoded UI values with dynamic, versioned metadata verified by the Model Validation team. Testing validates the full data lifecycle -- from ingestion of validated model metadata, through API exposure, to UI rendering and filtering -- ensuring customers can reliably discover and deploy tool-calling models.
+
+### 1.2 Scope
+
+#### In Scope (RHOAI AI Hub Responsibilities)
+- Extending the Model Catalog schema to include tool-calling-specific fields (tool_calling_supported, required_cli_args, chat_template_path, chat_template_file_name, tool_call_parser)
+- Ingesting validated tool-calling metadata provided by the Model Validation team into the Model Catalog
+- Tagging tool-calling-enabled models under the 'Other model' category
+- Rendering tool-calling commands in YAML frontmatter within modelcards for manual copy-paste (temporary workaround)
+- Exposing tool-calling metadata via the Model Catalog BFF API in JSON format for consumption by the RHOAI Serving Wizard
+- Auditing and ensuring models tagged as "Tool Calling Enabled" in the UI are backed by validated Catalog entries
+- Adding a 'Tool Calling' task filter to the left-hand navigation menu in the RHOAI Catalog UI
+- Supporting both upstream (`examples/<template_file_name>`) and downstream (`opt/app-root/template/<template_file_name>`) chat template paths
+- Handling the `--enable-auto-tool-choice` flag and `--tool-call-parser` argument requirements
+
+#### Out of Scope (Other Teams)
+- Direct integration with the RHOAI Serving Wizard to auto-populate deployment parameters (covered by RHAIRFE-1254)
+- Model validation testing itself (performed by Model Validation team under RHAISTRAT-1165)
+- Changes to RHAIIS or ModelCar image internals
+- Manual configuration workflows beyond the temporary copy-paste solution
+
+### 1.3 Test Objectives
+
+1. Verify that the Model Catalog schema accepts and correctly stores all required tool-calling metadata fields (tool_calling_supported, required_cli_args, chat_template_path, chat_template_file_name, tool_call_parser) for a model entry
+2. Confirm successful ingestion of a sample set of validated tool-calling models from RHAISTRAT-1165 with correct metadata, proper tags, and categorization under 'Other model'
+3. Validate that the Model Catalog BFF API returns tool-calling metadata in a structured JSON format that includes all required fields for a given model
+4. Ensure that the 'Tool Calling' task filter appears in the left-hand navigation menu and correctly filters models tagged with tool-calling support
+5. Verify that modelcards display tool-calling commands in YAML frontmatter in a user-readable, copy-paste-friendly format
+6. Confirm that only models with validated tool-calling entries in the Catalog can be tagged as "Tool Calling Enabled" in the UI (source of truth audit)
+7. Test that both upstream and downstream chat template path formats are correctly stored and retrievable via the API
+
+---
+
+## 2. Test Strategy
+
+### 2.1 Test Levels
+- **API Integration Testing** -- Validate that the Model Catalog BFF API correctly exposes tool-calling metadata fields in structured JSON format
+- **Data Validation Testing** -- Verify correct ingestion, storage, and retrieval of tool-calling metadata (CLI arguments, chat template paths, parser settings) in the Model Catalog database
+- **Functional Testing** -- Test catalog filtering by Tool Calling task, metadata rendering in modelcards, and tagging logic for tool-calling enabled models
+- **UI Testing** -- Verify Tool Calling filter appears in left navigation, models display correct metadata in cards, and copy-paste functionality works for CLI arguments
+
+### 2.2 Test Types
+- **Positive Testing** -- Validate successful ingestion of validated models with complete tool-calling metadata, correct API responses, UI filtering, and modelcard rendering
+- **Negative Testing** -- Test handling of incomplete metadata, invalid CLI arguments, missing chat template paths, and models incorrectly tagged as tool-calling enabled
+- **Boundary Testing** -- Validate behavior with maximum number of tool-calling models in catalog, long CLI argument strings, and edge cases in chat template path formats (upstream vs downstream)
+- **Regression Testing** -- Ensure existing Model Catalog functionality (search, filtering by other tasks, modelcard display) remains intact after schema updates
+
+### 2.3 Test Priorities
+- **P0 (Critical)** -- Core metadata schema functionality (BFF API returns tool-calling fields), successful ingestion of validated models from RHAISTRAT-1165, and Tool Calling filter operational in UI
+- **P1 (High)** -- Accurate rendering of CLI arguments in modelcards, correct tagging audit (only validated models tagged), and API data structure matches UI parsing requirements
+- **P2 (Medium)** -- UI refinements for copy-paste experience, comprehensive error handling for invalid metadata, and edge case handling for template path variations
+
+---
+
+## 3. Test Environment
+
+### 3.1 Test Cluster Configuration
+- OpenShift cluster with RHOAI 3.4 installed (Dev Preview release)
+- RHOAI AI Hub component enabled
+- RHOAI Model Serving component enabled
+- ModelCar operator/images (version confirmed to support both upstream and downstream chat template paths; specific version to be pinned once RHAIIS compatibility matrix is finalized)
+- Model Catalog BFF API deployed and accessible
+- RHOAI Serving UI deployed and accessible
+
+### 3.2 Test Data Requirements
+- Sample model metadata YAML files with tool-calling specific frontmatter fields (tool_calling_supported, required_cli_args, chat_template_file_name, chat_template_path, tool_call_parser)
+- Validated tool-calling models from RHAISTRAT-1165 initiative: minimum test data set of 3 validated models with complete tool-calling metadata, provided by Model Validation team or substituted with synthetic test entries conforming to the schema
+- Sample JSON payloads for Model Catalog API with tool-calling metadata structure
+- Chat template files for testing both upstream and downstream paths:
+  - Upstream format: `examples/<template_file_name>`
+  - Downstream format: `opt/app-root/template/<template_file_name>`
+- Sample CLI argument configurations including:
+  - `--enable-auto-tool-choice`
+  - `--tool-call-parser` variations
+  - Required CLI args to run models without tool calling (baseline)
+- Mock Model Validation team outputs (validated model entries with tool-calling parameters)
+
+### 3.3 Test Users
+- RHOAI admin user (for Model Catalog management and ingestion pipeline operations)
+- RHOAI data scientist user (for accessing Model Catalog UI and Serving Wizard)
+- Service account with permissions to query Model Catalog BFF API
+- Anonymous/unauthenticated user (to verify catalog browsing and filtering without deployment permissions)
+
+---
+
+## 4. API Endpoints / Methods Under Test
+
+| Endpoint/Method | Type | Purpose | Priority |
+|-----------------|------|---------|----------|
+| Model Catalog BFF API (model metadata endpoint) | REST | Return tool-calling metadata in JSON format for a specific model | P0 |
+| Model Catalog schema (database fields) | Config | Store tool_calling_supported, required_cli_args, chat_template_path, chat_template_file_name, tool_call_parser | P0 |
+| Model ingestion pipeline (validation team handoff) | Method/Process | Ingest validated tool-calling metadata into the Catalog | P0 |
+| Model tagging logic (UI audit) | Method | Ensure "Tool Calling Enabled" tag is backed by validated Catalog entry | P0 |
+| RHOAI Catalog UI -- 'Tool Calling' task filter | UI | Filter models by tool-calling support in left-hand navigation | P1 |
+| Modelcard rendering (YAML frontmatter) | UI | Display tool-calling commands for copy-paste | P1 |
+| Chat template path resolution logic | Method/Process | Validate correct template path returned based on upstream vs downstream format | P1 |
+
+---
+
+## 5. Test Cases
+
+> **42 test cases generated** across 8 categories. See the full index for details.
+
+**Test Cases Directory**: [test_cases/](test_cases/)
+**Complete Test Case Index**: [test_cases/INDEX.md](test_cases/INDEX.md)
+
+### 5.1 Test Case Organization
+
+| Category | Test Cases | Priority Distribution |
+|----------|------------|----------------------|
+| TC-SCHEMA | 7 | P0: 5, P1: 1, P2: 1 |
+| TC-INGEST | 6 | P0: 3, P1: 2, P2: 1 |
+| TC-API | 7 | P0: 3, P1: 3, P2: 1 |
+| TC-FILTER | 5 | P0: 2, P1: 2, P2: 1 |
+| TC-CARD | 5 | P0: 0, P1: 4, P2: 1 |
+| TC-AUDIT | 4 | P0: 2, P1: 2, P2: 0 |
+| TC-REG | 4 | P0: 0, P1: 4, P2: 0 |
+| TC-E2E | 4 | P0: 4, P1: 0, P2: 0 |
+| **Total** | **42** | **P0: 19, P1: 18, P2: 5** |
+
+### 5.2 Test Case Naming Convention
+
+Test cases follow the naming pattern: `TC-<CATEGORY>-<NUMBER>`
+
+- **TC-SCHEMA** -- Model Catalog schema enhancement and metadata field validation
+- **TC-INGEST** -- Ingestion pipeline and data import from Model Validation team
+- **TC-API** -- BFF API endpoint responses and JSON structure
+- **TC-FILTER** -- UI catalog filtering by Tool Calling task
+- **TC-CARD** -- Modelcard rendering and YAML frontmatter display
+- **TC-AUDIT** -- Source of truth audit and tag validation
+- **TC-REG** -- Regression testing for existing catalog functionality
+- **TC-E2E** -- End-to-end scenarios across ingestion, API, and UI
+
+---
+
+## 6. E2E Test Scenarios
+
+End-to-end scenarios that validate the user journeys defined in the strategy. Each scenario maps to one or more TC-E2E-*.md test cases generated by `/test-plan.create-cases`.
+
+> **Requirement**: At least one E2E scenario MUST be generated for each P0 endpoint in Section 4.
+> E2E scenarios will be filled by `/test-plan.create-cases`.
+
+### 6.1 Scenario Summary
+
+| ID | Scenario | Endpoints Covered | Priority |
+|----|----------|-------------------|----------|
+| TC-E2E-001 | Full model ingestion to API retrieval lifecycle | BFF API, Schema, Ingestion pipeline | P0 |
+| TC-E2E-002 | Model tagging audit and validation flow | Tagging logic, Ingestion pipeline | P0 |
+| TC-E2E-003 | Catalog discovery and modelcard viewing flow | Tool Calling filter, Modelcard rendering, BFF API | P0 |
+| TC-E2E-004 | Schema backwards compatibility with existing models | Schema, BFF API | P0 |
+
+### 6.2 E2E Coverage Matrix
+
+| Endpoint (from Section 4) | E2E Scenarios |
+|----------------------------|---------------|
+| Model Catalog BFF API (model metadata endpoint) | TC-E2E-001, TC-E2E-003, TC-E2E-004 |
+| Model Catalog schema (database fields) | TC-E2E-001, TC-E2E-004 |
+| Model ingestion pipeline (validation team handoff) | TC-E2E-001, TC-E2E-002 |
+| Model tagging logic (UI audit) | TC-E2E-002 |
+| RHOAI Catalog UI -- 'Tool Calling' task filter | TC-E2E-003 |
+| Modelcard rendering (YAML frontmatter) | TC-E2E-003 |
+| Chat template path resolution logic | TC-E2E-001 |
+
+---
+
+## 7. Non-Functional Requirements
+
+Each category below must be explicitly addressed. If a category does not apply to this feature, state **Not Applicable** with a brief justification.
+
+### 7.1 Disconnected/Air-Gapped
+
+**Not Applicable** -- This feature focuses on metadata storage and retrieval within the Model Catalog. While the models themselves may be deployed in disconnected environments, the catalog metadata integration does not introduce new external registry dependencies or runtime image pulls. The chat template paths reference locations within RHAIIS/ModelCar images already deployed.
+
+### 7.2 Upgrade/Migration
+
+Testing must validate:
+- **Schema evolution compatibility** -- Existing modelcards without tool-calling metadata must continue to function after schema enhancement
+- **Backwards compatibility** -- Models added before tool-calling metadata fields existed should not break catalog API responses or UI rendering
+- **Version-specific template paths** -- Ensure chat_template_path correctly distinguishes between upstream (`examples/<template_file_name>`) and downstream (`opt/app-root/template/<template_file_name>`) locations as RHAIIS and ModelCar image versions evolve
+- **Metadata update workflow** -- Test ability to update tool-calling metadata for existing models when validation team provides new CLI requirements
+
+### 7.3 Performance/Scalability
+
+Testing must validate:
+- **API response time** -- BFF API returns tool-calling metadata within acceptable latency when Serving UI queries model details (target: <500ms for single model lookup)
+- **Catalog UI rendering** -- Filtering by Tool Calling task and rendering modelcards with embedded CLI arguments should not degrade UI responsiveness with large model portfolios (test with 50+ models)
+- **Database query efficiency** -- Metadata retrieval should scale as the number of tool-calling enabled models grows over multiple releases
+
+### 7.4 RBAC/Authorization
+
+**Not Applicable** -- The strategy does not indicate new authorization boundaries for accessing tool-calling metadata. The Model Catalog BFF already enforces RBAC for model metadata access; those existing controls apply to the new tool-calling fields without additional testing scope.
+
+---
+
+## 8. Risks and Mitigation
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| Dependency on Model Validation team handoff timing and format of CLI arguments | High | Medium | Establish clear schema contract early, request sample data from validation team during test planning phase, automate validation of ingestion format |
+| Chat template path differences between upstream and downstream images may cause deployment failures if metadata is incorrect | High | Medium | Test both upstream and downstream path formats explicitly, validate against actual RHAIIS/ModelCar image contents, document path resolution logic |
+| UI parsing of BFF API JSON structure may fail if schema is not aligned between backend and frontend teams | High | Medium | Define API contract early with both Model Catalog and Serving UI teams, include API response validation in integration tests, perform end-to-end UI wizard testing |
+| Manual copy-paste from modelcard (temporary solution) introduces user error risk until RHAIRFE-1254 automation is delivered | Medium | High | Provide clear modelcard formatting, add validation examples in test data, document known limitations of Dev Preview implementation |
+| Inconsistent tagging of models as "Tool Calling Enabled" could mislead customers if validation process is incomplete | High | Medium | Implement automated audit process to verify all tagged models have complete validated metadata, include negative test cases for incorrectly tagged models |
+| Schema changes to Model Catalog database could break existing integrations or queries | Medium | Low | Test backwards compatibility with existing modelcards, validate that non-tool-calling models still render correctly, perform regression testing on all catalog API endpoints |
+| Model Catalog BFF API contract not yet finalized between backend and frontend teams | High | Medium | Track API specification progress as a dependency, use mock API responses for initial test development, validate contract alignment before E2E testing |
+
+---
+
+## 9. Test Environment Requirements
+
+### 9.1 Infrastructure
+- Single OpenShift cluster (sufficient for Dev Preview testing)
+- Model Catalog database (PostgreSQL or equivalent -- storage for enhanced metadata schema)
+- Model Catalog BFF API service endpoint
+- RHOAI Serving Wizard UI endpoint
+- Container registry access (for ModelCar images and validated models)
+- Model Validation team's testing suite output (external dependency -- handoff mechanism TBD)
+
+### 9.2 Configuration
+- Model Catalog schema migration/update scripts (to support new tool-calling fields)
+- Environment variables for Model Catalog BFF API endpoint
+- RHOAI Serving Wizard configuration pointing to Model Catalog API
+- Catalog source configuration for RHOAI 3.4 operators
+- Feature flags for Dev Preview functionality (if applicable)
+- Model Catalog UI left navigation configuration (to add 'Tool Calling' task filter)
+
+### 9.3 Test Tools
+- API testing tools: `curl`, `httpie`, or Postman (for Model Catalog BFF API validation)
+- Kubernetes CLI: `kubectl` or `oc` (for operator inspection, pod logs, resource verification)
+- JSON/YAML validation tools: `jq`, `yq` (for parsing API responses and metadata files)
+- Database query tools: `psql` or equivalent (for direct schema and data validation)
+- Browser developer tools (for UI inspection of Catalog filters and Serving Wizard behavior)
+- Git/version control (for tracking metadata schema changes and model entry updates)
+- Log viewing tools: `oc logs`, `stern` (for debugging ingestion pipeline and API errors)
+
+---
+
+## 10. Appendix
+
+### 10.1 Test Case Summary
+
+| Category | Total | P0 | P1 | P2 |
+|----------|-------|----|----|-----|
+| TC-SCHEMA | 7 | 5 | 1 | 1 |
+| TC-INGEST | 6 | 3 | 2 | 1 |
+| TC-API | 7 | 3 | 3 | 1 |
+| TC-FILTER | 5 | 2 | 2 | 1 |
+| TC-CARD | 5 | 0 | 4 | 1 |
+| TC-AUDIT | 4 | 2 | 2 | 0 |
+| TC-REG | 4 | 0 | 4 | 0 |
+| TC-E2E | 4 | 4 | 0 | 0 |
+| **Total** | **42** | **19** | **18** | **5** |
+
+### 10.2 Endpoint/Method Coverage
+
+| Endpoint | Test Cases | Coverage |
+|----------|------------|----------|
+| Model Catalog BFF API (model metadata endpoint) | TC-API-001, TC-API-002, TC-API-003, TC-API-004, TC-API-005, TC-API-006, TC-API-007, TC-E2E-001, TC-E2E-003, TC-E2E-004 | |
+| Model Catalog schema (database fields) | TC-SCHEMA-001, TC-SCHEMA-002, TC-SCHEMA-003, TC-SCHEMA-004, TC-SCHEMA-005, TC-SCHEMA-006, TC-SCHEMA-007, TC-E2E-001, TC-E2E-004 | |
+| Model ingestion pipeline (validation team handoff) | TC-INGEST-001, TC-INGEST-002, TC-INGEST-003, TC-INGEST-004, TC-INGEST-005, TC-INGEST-006, TC-E2E-001, TC-E2E-002 | |
+| Model tagging logic (UI audit) | TC-AUDIT-001, TC-AUDIT-002, TC-AUDIT-003, TC-AUDIT-004, TC-E2E-002 | |
+| RHOAI Catalog UI -- 'Tool Calling' task filter | TC-FILTER-001, TC-FILTER-002, TC-FILTER-003, TC-FILTER-004, TC-FILTER-005, TC-E2E-003 | |
+| Modelcard rendering (YAML frontmatter) | TC-CARD-001, TC-CARD-002, TC-CARD-003, TC-CARD-004, TC-CARD-005, TC-E2E-003 | |
+| Chat template path resolution logic | TC-API-005, TC-API-006, TC-SCHEMA-003, TC-CARD-005, TC-E2E-001 | |
+
+### 10.3 Document Change Log
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2026-04-13 | Initial test plan |
+| 1.1.0 | 2026-04-13 | Added 42 test cases across 8 categories, E2E scenarios, coverage matrix |
+
+---
+
+**End of Test Plan**

--- a/tool_calling_model_catalog/TestPlanGaps.md
+++ b/tool_calling_model_catalog/TestPlanGaps.md
@@ -1,0 +1,34 @@
+---
+feature: tool_calling_model_catalog
+strat_key: RHAISTRAT-1262
+status: Open
+gap_count: 21
+last_updated: '2026-04-13'
+---
+# Gaps -- Tool Calling Model Catalog
+
+## Scope & Endpoints
+- **BFF API specification** -- Exact REST API endpoint path, HTTP method, request/response schema, query parameters, error codes, and pagination are not specified. Would be resolved by: ADR / API spec
+- **Ingestion pipeline interface/API contract** -- How will Model Validation team output be consumed (manual upload, automated pipeline, webhook)? File format? Would be resolved by: ADR / design doc
+- **Database schema migration details (DDL, ORM models)** -- Migration scripts and ORM model definitions for the new fields are not specified. Would be resolved by: ADR / design doc
+- **UI component architecture for filter and modelcard rendering** -- UI component names for the 'Tool Calling' filter and modelcard rendering are not detailed. Would be resolved by: design doc / feature refinement
+- **Error handling and validation rules for metadata fields** -- Validation rules for required_cli_args list format (array of strings vs structured objects). Would be resolved by: ADR / API spec
+- **Versioning and rollback strategy for metadata changes** -- How template paths will be managed across RHAIIS/ModelCar image versions. Would be resolved by: ADR / design doc
+- **Authentication/authorization requirements for BFF API and ingestion pipeline** -- Specific RBAC rules for catalog ingestion and API consumption. Would be resolved by: ADR / API spec
+
+## Test Strategy & Risks
+- **Specific BFF API schema contract** -- What JSON structure will the BFF return? Which fields are required vs optional? Error response format? Would be resolved by: API spec
+- **Ingestion pipeline implementation details** -- Manual upload vs automated pipeline? File format? Would be resolved by: design doc or feature refinement
+- **Exact UI filter implementation** -- How does "Tool Calling" task integrate with existing left nav taxonomy? Is it a new top-level category or subcategory? Would be resolved by: feature refinement or design doc
+- **Validation criteria for "Tool Calling Enabled" tag** -- What constitutes a "validated" model? Which metadata fields must be present? Who approves tagging? Would be resolved by: feature refinement
+- **RHAIIS vs ModelCar image versioning strategy** -- How will template paths be managed across image versions? Is there a version mapping table? Would be resolved by: ADR
+
+## Environment & Infrastructure
+- **Model Validation team output format and handoff mechanism** -- Exact JSON/YAML structure, delivery mechanism, and update frequency. Would be resolved by: ADR or technical design doc
+- **Specific RHAIIS and ModelCar version requirements** -- Pins versions compatible with RHOAI 3.4 Dev Preview. Would be resolved by: feature refinement or ADR
+- **Model Catalog database schema migration strategy** -- Backward compatibility approach, rollback plan, and migration tooling. Would be resolved by: ADR
+- **List of validated models from RHAISTRAT-1165** -- Specific models to be used as test data. Would be resolved by: feature refinement or external dependency tracking
+- **API BFF endpoint specification for tool-calling metadata** -- Request/response schemas, query parameters for filtering, and error codes. Would be resolved by: API spec
+- **Exact permission requirements for service accounts and user roles** -- RBAC rules for catalog ingestion and API consumption. Would be resolved by: design doc or ADR
+- **Chat template file distribution mechanism** -- Whether templates are bundled with images, stored in ConfigMaps, or fetched dynamically. Would be resolved by: design doc
+- **UI filter implementation details for 'Tool Calling' task** -- Filter placement, interaction with existing filters, and backend query mapping. Would be resolved by: design doc or UI spec

--- a/tool_calling_model_catalog/test_cases/INDEX.md
+++ b/tool_calling_model_catalog/test_cases/INDEX.md
@@ -1,0 +1,95 @@
+# Test Case Index -- Tool Calling Model Catalog
+
+**Test Plan**: [TestPlan.md](../TestPlan.md)
+**Strategy**: [RHAISTRAT-1262](https://redhat.atlassian.net/browse/RHAISTRAT-1262)
+
+## Quick Stats
+
+| Metric | Count |
+|--------|-------|
+| Total Test Cases | 42 |
+| P0 (Critical) | 19 |
+| P1 (High) | 18 |
+| P2 (Medium) | 5 |
+
+## TC-SCHEMA -- Schema Enhancement and Metadata Field Validation
+
+| Test Case ID | Title | Priority |
+|-------------|-------|----------|
+| [TC-SCHEMA-001](TC-SCHEMA-001.md) | Store tool_calling_supported boolean field in Model Catalog | P0 |
+| [TC-SCHEMA-002](TC-SCHEMA-002.md) | Store required_cli_args list field in Model Catalog | P0 |
+| [TC-SCHEMA-003](TC-SCHEMA-003.md) | Store chat_template_path and chat_template_file_name fields | P0 |
+| [TC-SCHEMA-004](TC-SCHEMA-004.md) | Store tool_call_parser string field in Model Catalog | P0 |
+| [TC-SCHEMA-005](TC-SCHEMA-005.md) | Existing models without tool-calling fields remain functional after schema update | P0 |
+| [TC-SCHEMA-006](TC-SCHEMA-006.md) | Schema handles empty required_cli_args list | P1 |
+| [TC-SCHEMA-007](TC-SCHEMA-007.md) | Schema rejects invalid field types for tool-calling metadata | P2 |
+
+## TC-INGEST -- Ingestion Pipeline and Data Import
+
+| Test Case ID | Title | Priority |
+|-------------|-------|----------|
+| [TC-INGEST-001](TC-INGEST-001.md) | Ingest single validated model with complete tool-calling metadata | P0 |
+| [TC-INGEST-002](TC-INGEST-002.md) | Ingest batch of validated tool-calling models from RHAISTRAT-1165 | P0 |
+| [TC-INGEST-003](TC-INGEST-003.md) | Verify ingested model tagged under 'Other model' category | P0 |
+| [TC-INGEST-004](TC-INGEST-004.md) | Update tool-calling metadata for previously ingested model | P1 |
+| [TC-INGEST-005](TC-INGEST-005.md) | Ingest model with partial tool-calling metadata | P1 |
+| [TC-INGEST-006](TC-INGEST-006.md) | Reject ingestion of model with malformed metadata | P2 |
+
+## TC-API -- BFF API Endpoint Responses and JSON Structure
+
+| Test Case ID | Title | Priority |
+|-------------|-------|----------|
+| [TC-API-001](TC-API-001.md) | Retrieve tool-calling metadata for a validated model via BFF API | P0 |
+| [TC-API-002](TC-API-002.md) | Verify JSON response structure includes all required tool-calling fields | P0 |
+| [TC-API-003](TC-API-003.md) | Verify --enable-auto-tool-choice flag data in API response | P0 |
+| [TC-API-004](TC-API-004.md) | Retrieve metadata for model without tool-calling support | P1 |
+| [TC-API-005](TC-API-005.md) | Verify upstream chat template path in API response | P1 |
+| [TC-API-006](TC-API-006.md) | Verify downstream chat template path in API response | P1 |
+| [TC-API-007](TC-API-007.md) | Request metadata for non-existent model returns appropriate error | P2 |
+
+## TC-FILTER -- UI Catalog Filtering by Tool Calling Task
+
+| Test Case ID | Title | Priority |
+|-------------|-------|----------|
+| [TC-FILTER-001](TC-FILTER-001.md) | 'Tool Calling' task filter visible in left navigation menu | P0 |
+| [TC-FILTER-002](TC-FILTER-002.md) | Filter returns only tool-calling-enabled models | P0 |
+| [TC-FILTER-003](TC-FILTER-003.md) | Tool Calling filter combined with existing task filters | P1 |
+| [TC-FILTER-004](TC-FILTER-004.md) | Tool Calling filter shows correct model count | P1 |
+| [TC-FILTER-005](TC-FILTER-005.md) | Tool Calling filter with no matching models displays empty state | P2 |
+
+## TC-CARD -- Modelcard Rendering and YAML Frontmatter Display
+
+| Test Case ID | Title | Priority |
+|-------------|-------|----------|
+| [TC-CARD-001](TC-CARD-001.md) | Modelcard displays tool-calling CLI arguments in YAML frontmatter | P1 |
+| [TC-CARD-002](TC-CARD-002.md) | CLI arguments on modelcard are copy-paste friendly | P1 |
+| [TC-CARD-003](TC-CARD-003.md) | Modelcard shows --enable-auto-tool-choice and --tool-call-parser flags | P1 |
+| [TC-CARD-004](TC-CARD-004.md) | Modelcard without tool-calling metadata renders without errors | P1 |
+| [TC-CARD-005](TC-CARD-005.md) | Modelcard displays both upstream and downstream template paths | P2 |
+
+## TC-AUDIT -- Source of Truth Audit and Tag Validation
+
+| Test Case ID | Title | Priority |
+|-------------|-------|----------|
+| [TC-AUDIT-001](TC-AUDIT-001.md) | Model with validated catalog entry shows "Tool Calling Enabled" tag | P0 |
+| [TC-AUDIT-002](TC-AUDIT-002.md) | Model without validated entry cannot display "Tool Calling Enabled" tag | P0 |
+| [TC-AUDIT-003](TC-AUDIT-003.md) | Tag removed when model's validated entry is removed from catalog | P1 |
+| [TC-AUDIT-004](TC-AUDIT-004.md) | Audit identifies inconsistencies between tags and catalog entries | P1 |
+
+## TC-REG -- Regression Testing
+
+| Test Case ID | Title | Priority |
+|-------------|-------|----------|
+| [TC-REG-001](TC-REG-001.md) | Existing model search functionality unaffected by schema update | P1 |
+| [TC-REG-002](TC-REG-002.md) | Existing task filters operational after adding Tool Calling filter | P1 |
+| [TC-REG-003](TC-REG-003.md) | Existing modelcard display unaffected by schema changes | P1 |
+| [TC-REG-004](TC-REG-004.md) | Existing BFF API responses for non-tool-calling models unchanged | P1 |
+
+## TC-E2E -- End-to-End Scenarios
+
+| Test Case ID | Title | Priority |
+|-------------|-------|----------|
+| [TC-E2E-001](TC-E2E-001.md) | Full model ingestion to API retrieval lifecycle | P0 |
+| [TC-E2E-002](TC-E2E-002.md) | Model tagging audit and validation flow | P0 |
+| [TC-E2E-003](TC-E2E-003.md) | Catalog discovery and modelcard viewing flow | P0 |
+| [TC-E2E-004](TC-E2E-004.md) | Schema backwards compatibility with existing models | P0 |

--- a/tool_calling_model_catalog/test_cases/TC-API-001.md
+++ b/tool_calling_model_catalog/test_cases/TC-API-001.md
@@ -1,0 +1,44 @@
+---
+test_case_id: TC-API-001
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-API-001: Retrieve tool-calling metadata for a validated model via BFF API
+
+**Objective**: Verify that the Model Catalog BFF API returns the complete tool-calling metadata for a validated model in structured JSON format.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog BFF API deployed
+- At least one validated tool-calling model ingested (e.g., granite-3.1-8b-instruct)
+
+**Test Steps**:
+1. Send a GET request to the Model Catalog BFF API for the granite-3.1-8b-instruct model
+2. Verify the HTTP response status is 200 OK
+3. Parse the JSON response body
+4. Verify the response contains `tool_calling_supported: true`
+5. Verify the response contains `required_cli_args` as a non-empty array
+6. Verify the response contains `chat_template_path` as a non-empty string
+7. Verify the response contains `chat_template_file_name` as a non-empty string
+8. Verify the response contains `tool_call_parser` as a non-empty string
+
+**Expected Results**:
+- Response status is 200
+- JSON body includes all five tool-calling metadata fields with correct types
+- Field values match the data ingested for the model
+
+**Expected Response**:
+```json
+{
+  "model_id": "granite-3.1-8b-instruct",
+  "tool_calling_supported": true,
+  "required_cli_args": ["--max-model-len", "8192", "--dtype", "float16"],
+  "chat_template_path": "examples/tool_chat_template_granite.jinja",
+  "chat_template_file_name": "tool_chat_template_granite.jinja",
+  "tool_call_parser": "hermes"
+}
+```
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-API-001.md
+++ b/tool_calling_model_catalog/test_cases/TC-API-001.md
@@ -3,8 +3,12 @@ test_case_id: TC-API-001
 strat_key: RHAISTRAT-1262
 priority: P0
 status: Draft
-automation_status: Not Started
+automation_status: Implemented
 last_updated: '2026-04-13'
+automation_file: tests/model_registry/model_catalog/metadata/test_tool_calling_metadata.py
+automation_function: TestToolCallingMetadata::test_tool_calling_metadata_fields_present
+automated_by: claude-test-plan.case-implement
+automated_date: '2026-04-17'
 ---
 # TC-API-001: Retrieve tool-calling metadata for a validated model via BFF API
 

--- a/tool_calling_model_catalog/test_cases/TC-API-001.md
+++ b/tool_calling_model_catalog/test_cases/TC-API-001.md
@@ -2,13 +2,9 @@
 test_case_id: TC-API-001
 strat_key: RHAISTRAT-1262
 priority: P0
-status: Draft
-automation_status: Implemented
-last_updated: '2026-04-13'
-automation_file: tests/model_registry/model_catalog/metadata/test_tool_calling_metadata.py
-automation_function: TestToolCallingMetadata::test_tool_calling_metadata_fields_present
-automated_by: claude-test-plan.case-implement
-automated_date: '2026-04-17'
+status: Automated
+automation_status: Complete
+last_updated: '2026-04-17'
 ---
 # TC-API-001: Retrieve tool-calling metadata for a validated model via BFF API
 

--- a/tool_calling_model_catalog/test_cases/TC-API-002.md
+++ b/tool_calling_model_catalog/test_cases/TC-API-002.md
@@ -1,0 +1,35 @@
+---
+test_case_id: TC-API-002
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-API-002: Verify JSON response structure includes all required tool-calling fields
+
+**Objective**: Verify that the BFF API response schema for tool-calling models includes all required fields in the correct structure parseable by the RHOAI Serving UI.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog BFF API deployed
+- Multiple validated tool-calling models ingested with different metadata values
+
+**Test Steps**:
+1. Send a GET request for the granite-3.1-8b-instruct model
+2. Validate the response against the expected JSON schema:
+   - `tool_calling_supported` must be a boolean
+   - `required_cli_args` must be an array of strings
+   - `chat_template_path` must be a string
+   - `chat_template_file_name` must be a string
+   - `tool_call_parser` must be a string
+3. Repeat for the llama-3.3-70b-instruct model
+4. Verify both responses follow the same schema structure
+5. Verify field names are consistent (no camelCase vs snake_case inconsistencies)
+
+**Expected Results**:
+- All responses follow the same JSON schema
+- Field names use snake_case consistently
+- Field types are consistent across different models
+- The structure is suitable for direct consumption by the RHOAI Serving UI
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-API-002.md
+++ b/tool_calling_model_catalog/test_cases/TC-API-002.md
@@ -2,9 +2,9 @@
 test_case_id: TC-API-002
 strat_key: RHAISTRAT-1262
 priority: P0
-status: Draft
-automation_status: Not Started
-last_updated: '2026-04-13'
+status: Automated
+automation_status: Complete
+last_updated: '2026-04-17'
 ---
 # TC-API-002: Verify JSON response structure includes all required tool-calling fields
 

--- a/tool_calling_model_catalog/test_cases/TC-API-003.md
+++ b/tool_calling_model_catalog/test_cases/TC-API-003.md
@@ -2,9 +2,9 @@
 test_case_id: TC-API-003
 strat_key: RHAISTRAT-1262
 priority: P0
-status: Draft
-automation_status: Not Started
-last_updated: '2026-04-13'
+status: Automated
+automation_status: Complete
+last_updated: '2026-04-17'
 ---
 # TC-API-003: Verify --enable-auto-tool-choice flag data in API response
 

--- a/tool_calling_model_catalog/test_cases/TC-API-003.md
+++ b/tool_calling_model_catalog/test_cases/TC-API-003.md
@@ -1,0 +1,40 @@
+---
+test_case_id: TC-API-003
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-API-003: Verify --enable-auto-tool-choice flag data in API response
+
+**Objective**: Verify that the BFF API response includes the `--enable-auto-tool-choice` flag information so the Serving UI knows this flag is required for tool-calling deployment.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog BFF API deployed
+- A validated tool-calling model ingested with auto-tool-choice requirement
+
+**Test Steps**:
+1. Ingest a model with metadata indicating `--enable-auto-tool-choice` is required (either as part of `required_cli_args` or as a separate field)
+2. Send a GET request to the BFF API for the model
+3. Verify the response includes information about the `--enable-auto-tool-choice` flag
+4. Verify the flag information is in a format consumable by the Serving UI
+5. Verify a model without tool-calling support does NOT include this flag in its response
+
+**Expected Results**:
+- The `--enable-auto-tool-choice` flag is included in the tool-calling metadata
+- The flag is distinguishable from model-specific CLI args (baseline args vs tool-calling-specific args)
+- The Serving UI can programmatically determine when to include this flag in deployment commands
+
+**Test Data**:
+```json
+{
+  "model_id": "granite-3.1-8b-instruct",
+  "tool_calling_supported": true,
+  "required_cli_args": ["--max-model-len", "8192"],
+  "chat_template_path": "examples/tool_chat_template_granite.jinja",
+  "tool_call_parser": "hermes"
+}
+```
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-API-004.md
+++ b/tool_calling_model_catalog/test_cases/TC-API-004.md
@@ -1,0 +1,29 @@
+---
+test_case_id: TC-API-004
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-API-004: Retrieve metadata for model without tool-calling support
+
+**Objective**: Verify that the BFF API returns a well-formed response for a model that does not have tool-calling support, with tool-calling fields absent or null.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog BFF API deployed
+- A model ingested without tool-calling metadata (pre-existing or explicitly `tool_calling_supported: false`)
+
+**Test Steps**:
+1. Send a GET request to the BFF API for a non-tool-calling model (e.g., a text-generation-only model)
+2. Verify the HTTP response status is 200 OK
+3. Verify `tool_calling_supported` is `false` or absent
+4. Verify `required_cli_args`, `chat_template_path`, `chat_template_file_name`, and `tool_call_parser` are null, empty, or absent
+5. Verify the response does not include any tool-calling-specific fields with placeholder or default values that could be mistaken for real metadata
+
+**Expected Results**:
+- Response is valid JSON with 200 status
+- Tool-calling fields are clearly absent or null, not populated with defaults
+- The Serving UI can reliably determine this model does not support tool calling
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-API-004.md
+++ b/tool_calling_model_catalog/test_cases/TC-API-004.md
@@ -2,9 +2,9 @@
 test_case_id: TC-API-004
 strat_key: RHAISTRAT-1262
 priority: P1
-status: Draft
-automation_status: Not Started
-last_updated: '2026-04-13'
+status: Automated
+automation_status: Complete
+last_updated: '2026-04-17'
 ---
 # TC-API-004: Retrieve metadata for model without tool-calling support
 

--- a/tool_calling_model_catalog/test_cases/TC-API-005.md
+++ b/tool_calling_model_catalog/test_cases/TC-API-005.md
@@ -2,9 +2,9 @@
 test_case_id: TC-API-005
 strat_key: RHAISTRAT-1262
 priority: P1
-status: Draft
-automation_status: Not Started
-last_updated: '2026-04-13'
+status: Automated
+automation_status: Complete
+last_updated: '2026-04-17'
 ---
 # TC-API-005: Verify upstream chat template path in API response
 

--- a/tool_calling_model_catalog/test_cases/TC-API-005.md
+++ b/tool_calling_model_catalog/test_cases/TC-API-005.md
@@ -1,0 +1,29 @@
+---
+test_case_id: TC-API-005
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-API-005: Verify upstream chat template path in API response
+
+**Objective**: Verify that the BFF API correctly returns the upstream format chat template path (`examples/<template_file_name>`) for models using upstream template locations.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog BFF API deployed
+- A model ingested with upstream chat template path format
+
+**Test Steps**:
+1. Ingest a model with `chat_template_path: "examples/tool_chat_template_granite.jinja"`
+2. Send a GET request to the BFF API for the model
+3. Verify `chat_template_path` is exactly `"examples/tool_chat_template_granite.jinja"`
+4. Verify `chat_template_file_name` is `"tool_chat_template_granite.jinja"`
+5. Verify the path prefix is `examples/` (upstream format)
+
+**Expected Results**:
+- Upstream path format is preserved exactly as ingested
+- No path transformation or normalization is applied
+- The `chat_template_file_name` is consistent with the filename portion of `chat_template_path`
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-API-006.md
+++ b/tool_calling_model_catalog/test_cases/TC-API-006.md
@@ -1,0 +1,29 @@
+---
+test_case_id: TC-API-006
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-API-006: Verify downstream chat template path in API response
+
+**Objective**: Verify that the BFF API correctly returns the downstream format chat template path (`opt/app-root/template/<template_file_name>`) for RHOAI deployments.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog BFF API deployed
+- A model ingested with downstream chat template path format
+
+**Test Steps**:
+1. Ingest a model with `chat_template_path: "opt/app-root/template/tool_chat_template_granite.jinja"`
+2. Send a GET request to the BFF API for the model
+3. Verify `chat_template_path` is exactly `"opt/app-root/template/tool_chat_template_granite.jinja"`
+4. Verify `chat_template_file_name` is `"tool_chat_template_granite.jinja"`
+5. Verify the path prefix is `opt/app-root/template/` (downstream format)
+
+**Expected Results**:
+- Downstream path format is preserved exactly as ingested
+- No path transformation or normalization is applied
+- The `chat_template_file_name` is consistent with the filename portion of `chat_template_path`
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-API-006.md
+++ b/tool_calling_model_catalog/test_cases/TC-API-006.md
@@ -2,9 +2,9 @@
 test_case_id: TC-API-006
 strat_key: RHAISTRAT-1262
 priority: P1
-status: Draft
-automation_status: Not Started
-last_updated: '2026-04-13'
+status: Automated
+automation_status: Complete
+last_updated: '2026-04-17'
 ---
 # TC-API-006: Verify downstream chat template path in API response
 

--- a/tool_calling_model_catalog/test_cases/TC-API-007.md
+++ b/tool_calling_model_catalog/test_cases/TC-API-007.md
@@ -2,9 +2,9 @@
 test_case_id: TC-API-007
 strat_key: RHAISTRAT-1262
 priority: P2
-status: Draft
-automation_status: Not Started
-last_updated: '2026-04-13'
+status: Automated
+automation_status: Complete
+last_updated: '2026-04-17'
 ---
 # TC-API-007: Request metadata for non-existent model returns appropriate error
 

--- a/tool_calling_model_catalog/test_cases/TC-API-007.md
+++ b/tool_calling_model_catalog/test_cases/TC-API-007.md
@@ -1,0 +1,25 @@
+---
+test_case_id: TC-API-007
+strat_key: RHAISTRAT-1262
+priority: P2
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-API-007: Request metadata for non-existent model returns appropriate error
+
+**Objective**: Verify that the BFF API returns an appropriate error response when queried for a model that does not exist in the catalog.
+
+**Test Steps**:
+1. Send a GET request to the BFF API for a model ID that does not exist (e.g., `nonexistent-model-v99`)
+2. Verify the HTTP response status is 404 Not Found
+3. Verify the response body contains an error message indicating the model was not found
+4. Verify the error response is valid JSON
+5. Verify no sensitive internal information (stack traces, database details) is leaked in the error response
+
+**Expected Results**:
+- Response status is 404
+- Error message is descriptive but safe (e.g., `{"error": "Model not found", "model_id": "nonexistent-model-v99"}`)
+- No 500 Internal Server Error or unhandled exception
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-AUDIT-001.md
+++ b/tool_calling_model_catalog/test_cases/TC-AUDIT-001.md
@@ -1,0 +1,31 @@
+---
+test_case_id: TC-AUDIT-001
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-AUDIT-001: Model with validated catalog entry shows "Tool Calling Enabled" tag
+
+**Objective**: Verify that a model with a validated tool-calling entry in the catalog correctly displays the "Tool Calling Enabled" tag in the UI.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- A model ingested with complete, validated tool-calling metadata via the ingestion pipeline
+
+**Test Steps**:
+1. Ingest a model (granite-3.1-8b-instruct) with complete tool-calling metadata through the validated ingestion pipeline
+2. Navigate to the RHOAI Model Catalog UI
+3. Locate the granite-3.1-8b-instruct model in the catalog listing
+4. Verify the model displays a "Tool Calling Enabled" tag or equivalent indicator
+5. Click on the model to view the modelcard
+6. Verify the modelcard also shows the "Tool Calling Enabled" status
+7. Query the BFF API and confirm `tool_calling_supported: true` matches the UI display
+
+**Expected Results**:
+- "Tool Calling Enabled" tag is visible in both catalog listing and modelcard views
+- Tag presence is backed by validated metadata in the catalog database
+- Tag and API data are consistent
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-AUDIT-002.md
+++ b/tool_calling_model_catalog/test_cases/TC-AUDIT-002.md
@@ -1,0 +1,30 @@
+---
+test_case_id: TC-AUDIT-002
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-AUDIT-002: Model without validated entry cannot display "Tool Calling Enabled" tag
+
+**Objective**: Verify that a model without a validated tool-calling entry in the catalog cannot display the "Tool Calling Enabled" tag, ensuring the catalog is the single source of truth.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- A model in the catalog without tool-calling metadata
+
+**Test Steps**:
+1. Identify a model in the catalog that does not have `tool_calling_supported: true` in its metadata
+2. Navigate to the model in the RHOAI Catalog UI
+3. Verify the model does NOT display a "Tool Calling Enabled" tag in the catalog listing
+4. View the modelcard and verify no tool-calling indicators are present
+5. Attempt to manually add a "Tool Calling" tag to the model (if the UI allows manual tagging)
+6. Verify the system prevents tagging a model as tool-calling-enabled without validated catalog metadata, OR verify that the audit process would flag this inconsistency
+
+**Expected Results**:
+- Models without validated tool-calling metadata cannot display the "Tool Calling Enabled" tag
+- The UI enforces consistency between catalog metadata and displayed tags
+- No false positives where non-validated models appear as tool-calling capable
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-AUDIT-003.md
+++ b/tool_calling_model_catalog/test_cases/TC-AUDIT-003.md
@@ -1,0 +1,31 @@
+---
+test_case_id: TC-AUDIT-003
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-AUDIT-003: Tag removed when model's validated entry is removed from catalog
+
+**Objective**: Verify that removing or invalidating a model's tool-calling metadata from the catalog also removes the "Tool Calling Enabled" tag from the UI.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- A model currently displaying the "Tool Calling Enabled" tag with validated metadata
+
+**Test Steps**:
+1. Confirm the granite-3.1-8b-instruct model has "Tool Calling Enabled" tag in the UI
+2. Remove or set `tool_calling_supported: false` for the model in the catalog
+3. Refresh the RHOAI Catalog UI
+4. Verify the "Tool Calling Enabled" tag is no longer displayed for the model
+5. Apply the 'Tool Calling' filter and verify the model no longer appears in filtered results
+6. Query the BFF API and confirm `tool_calling_supported` is now `false` or absent
+
+**Expected Results**:
+- Tag is removed from the UI after metadata is removed/invalidated
+- Model no longer appears in Tool Calling filter results
+- API response reflects the updated state
+- No stale cached tags remain in the UI
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-AUDIT-004.md
+++ b/tool_calling_model_catalog/test_cases/TC-AUDIT-004.md
@@ -1,0 +1,31 @@
+---
+test_case_id: TC-AUDIT-004
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-AUDIT-004: Audit identifies inconsistencies between tags and catalog entries
+
+**Objective**: Verify that the source of truth audit process can detect and report models that are tagged as "Tool Calling Enabled" in the UI but lack validated metadata in the catalog.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog deployed
+- An audit mechanism or report is available for validating tag-metadata consistency
+
+**Test Steps**:
+1. Ingest a model with complete tool-calling metadata (valid state)
+2. Manually create an inconsistent state: apply the "Tool Calling Enabled" tag to a model that does NOT have validated tool-calling metadata (if possible via direct DB manipulation or admin API)
+3. Run the source of truth audit process
+4. Verify the audit report identifies the inconsistency (model tagged without validated metadata)
+5. Verify the audit report includes the model ID and the nature of the inconsistency
+6. Verify the valid model (from step 1) passes the audit without issues
+
+**Expected Results**:
+- Audit detects the tag-metadata mismatch
+- Report includes actionable details: model ID, missing fields, recommendation
+- Valid models pass the audit without false positives
+- Audit does not modify data -- it only reports findings
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-CARD-001.md
+++ b/tool_calling_model_catalog/test_cases/TC-CARD-001.md
@@ -1,0 +1,32 @@
+---
+test_case_id: TC-CARD-001
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-CARD-001: Modelcard displays tool-calling CLI arguments in YAML frontmatter
+
+**Objective**: Verify that a modelcard for a tool-calling-enabled model displays the CLI arguments in YAML frontmatter format within the card's detail view.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- A tool-calling model ingested with complete CLI argument metadata
+
+**Test Steps**:
+1. Navigate to the RHOAI Model Catalog UI
+2. Locate and click on a tool-calling-enabled model (e.g., granite-3.1-8b-instruct)
+3. Open the modelcard detail view
+4. Verify the YAML frontmatter section is visible on the modelcard
+5. Verify the frontmatter includes `tool_calling_supported: true`
+6. Verify the frontmatter includes the `required_cli_args` list
+7. Verify the frontmatter includes `tool_call_parser` value
+8. Verify the frontmatter includes `chat_template_path` value
+
+**Expected Results**:
+- YAML frontmatter is displayed in a readable, structured format
+- All tool-calling fields are present and correctly formatted
+- The content matches the metadata stored in the catalog
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-CARD-002.md
+++ b/tool_calling_model_catalog/test_cases/TC-CARD-002.md
@@ -1,0 +1,33 @@
+---
+test_case_id: TC-CARD-002
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-CARD-002: CLI arguments on modelcard are copy-paste friendly
+
+**Objective**: Verify that the tool-calling CLI arguments displayed on the modelcard can be easily copied and pasted by users for manual deployment configuration.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- A tool-calling model ingested with CLI arguments and chat template path
+
+**Test Steps**:
+1. Navigate to the modelcard for granite-3.1-8b-instruct
+2. Locate the YAML frontmatter section displaying tool-calling commands
+3. Select and copy the CLI arguments text from the modelcard
+4. Paste the copied text into a text editor
+5. Verify the pasted text is clean (no extra whitespace, HTML tags, or formatting artifacts)
+6. Verify the pasted CLI arguments can be used directly in a vLLM deployment command:
+   ```
+   --chat-template examples/tool_chat_template_granite.jinja --tool-call-parser hermes --enable-auto-tool-choice
+   ```
+
+**Expected Results**:
+- Copied text is clean and directly usable in CLI commands
+- No hidden characters or formatting artifacts in the copied text
+- Line breaks and indentation are preserved appropriately
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-CARD-003.md
+++ b/tool_calling_model_catalog/test_cases/TC-CARD-003.md
@@ -1,0 +1,30 @@
+---
+test_case_id: TC-CARD-003
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-CARD-003: Modelcard shows --enable-auto-tool-choice and --tool-call-parser flags
+
+**Objective**: Verify that the modelcard renders the `--enable-auto-tool-choice` flag and `--tool-call-parser` argument prominently so users know these are required for tool-calling deployments.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- A tool-calling model ingested with tool_call_parser metadata
+
+**Test Steps**:
+1. Navigate to the modelcard for granite-3.1-8b-instruct
+2. Verify the modelcard displays `--enable-auto-tool-choice` as a required flag for tool-calling
+3. Verify the modelcard displays `--tool-call-parser hermes` (or the model-specific parser)
+4. Verify these flags are visually distinct or grouped together as tool-calling requirements
+5. Navigate to the modelcard for llama-3.3-70b-instruct
+6. Verify the modelcard displays `--tool-call-parser llama3_json` (different parser for this model)
+
+**Expected Results**:
+- Both `--enable-auto-tool-choice` and `--tool-call-parser <parser>` are visible on the modelcard
+- The parser value is model-specific and matches the ingested metadata
+- The flags are clearly labeled as tool-calling deployment requirements
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-CARD-004.md
+++ b/tool_calling_model_catalog/test_cases/TC-CARD-004.md
@@ -1,0 +1,31 @@
+---
+test_case_id: TC-CARD-004
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-CARD-004: Modelcard without tool-calling metadata renders without errors
+
+**Objective**: Verify that a modelcard for a model without tool-calling support renders correctly without any errors or broken UI elements related to missing tool-calling fields.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- A model ingested without tool-calling metadata (e.g., a text-generation-only model)
+
+**Test Steps**:
+1. Navigate to the RHOAI Model Catalog UI
+2. Locate and click on a model without tool-calling support
+3. Open the modelcard detail view
+4. Verify the modelcard renders without JavaScript errors (check browser console)
+5. Verify no empty or broken tool-calling sections appear on the card
+6. Verify the modelcard's existing content (description, tags, other metadata) is displayed correctly
+
+**Expected Results**:
+- Modelcard renders cleanly without tool-calling section
+- No placeholder text like "N/A" or "undefined" for tool-calling fields
+- No console errors related to missing tool-calling metadata
+- Model's existing metadata is unaffected
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-CARD-005.md
+++ b/tool_calling_model_catalog/test_cases/TC-CARD-005.md
@@ -1,0 +1,30 @@
+---
+test_case_id: TC-CARD-005
+strat_key: RHAISTRAT-1262
+priority: P2
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-CARD-005: Modelcard displays both upstream and downstream template paths
+
+**Objective**: Verify that modelcards correctly display chat template paths in both upstream and downstream formats, enabling users to identify the correct path for their deployment environment.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- Models ingested with both upstream and downstream chat template path formats
+
+**Test Steps**:
+1. Navigate to the modelcard for a model with upstream template path (`examples/tool_chat_template_granite.jinja`)
+2. Verify the upstream path is displayed clearly in the YAML frontmatter
+3. Navigate to the modelcard for a model with downstream template path (`opt/app-root/template/tool_chat_template_granite.jinja`)
+4. Verify the downstream path is displayed clearly in the YAML frontmatter
+5. Verify both paths are rendered without truncation
+6. Verify users can distinguish between upstream and downstream paths
+
+**Expected Results**:
+- Both path formats are fully visible without truncation
+- Paths are displayed verbatim as stored in the catalog
+- No path transformation or substitution occurs in the UI rendering
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-E2E-001.md
+++ b/tool_calling_model_catalog/test_cases/TC-E2E-001.md
@@ -1,0 +1,55 @@
+---
+test_case_id: TC-E2E-001
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-E2E-001: Full model ingestion to API retrieval lifecycle
+
+**Objective**: Validate the complete lifecycle of ingesting a validated tool-calling model and retrieving its metadata through the BFF API, confirming the Model Catalog serves as the single source of truth.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog, BFF API, and Catalog UI fully deployed
+- Model Validation team output available (or synthetic test data)
+
+**Test Steps**:
+1. Prepare a validated model entry for granite-3.1-8b-instruct with complete tool-calling metadata:
+   ```yaml
+   tool_calling_supported: true
+   required_cli_args: ["--max-model-len", "8192", "--dtype", "float16"]
+   chat_template_path: "examples/tool_chat_template_granite.jinja"
+   chat_template_file_name: "tool_chat_template_granite.jinja"
+   tool_call_parser: "hermes"
+   ```
+2. Submit the model entry to the ingestion pipeline
+3. Verify the ingestion completes successfully (check pipeline logs/status)
+4. Query the Model Catalog database directly to confirm the entry exists with all fields
+5. Send a GET request to the BFF API for granite-3.1-8b-instruct
+6. Verify the API response contains all five tool-calling fields with correct values
+7. Verify `tool_calling_supported` is `true`
+8. Verify `required_cli_args` is `["--max-model-len", "8192", "--dtype", "float16"]`
+9. Verify `chat_template_path` is `"examples/tool_chat_template_granite.jinja"`
+10. Verify `tool_call_parser` is `"hermes"`
+
+**Expected Results**:
+- Ingestion succeeds without errors
+- Database contains the complete, accurate model entry
+- BFF API returns the same data as stored in the database
+- Data integrity is maintained across all layers (ingestion -> storage -> API)
+
+**Test Data**:
+```json
+{
+  "model_id": "granite-3.1-8b-instruct",
+  "model_name": "Granite 3.1 8B Instruct",
+  "tool_calling_supported": true,
+  "required_cli_args": ["--max-model-len", "8192", "--dtype", "float16"],
+  "chat_template_path": "examples/tool_chat_template_granite.jinja",
+  "chat_template_file_name": "tool_chat_template_granite.jinja",
+  "tool_call_parser": "hermes"
+}
+```
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-E2E-002.md
+++ b/tool_calling_model_catalog/test_cases/TC-E2E-002.md
@@ -1,0 +1,34 @@
+---
+test_case_id: TC-E2E-002
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-E2E-002: Model tagging audit and validation flow
+
+**Objective**: Validate the end-to-end flow of ingesting a model, verifying its "Tool Calling Enabled" tag is backed by validated catalog data, and confirming the audit process detects invalid states.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog, BFF API, and Catalog UI fully deployed
+- Audit mechanism available for tag-metadata consistency checks
+
+**Test Steps**:
+1. Ingest granite-3.1-8b-instruct with complete, validated tool-calling metadata
+2. Navigate to the Catalog UI and verify the "Tool Calling Enabled" tag is displayed for the model
+3. Query the BFF API and confirm `tool_calling_supported: true`
+4. Run the source of truth audit process
+5. Verify granite-3.1-8b-instruct passes the audit (tag is backed by validated metadata)
+6. Ingest a second model (flan-t5-small) WITHOUT tool-calling metadata
+7. Verify flan-t5-small does NOT display the "Tool Calling Enabled" tag
+8. Run the audit again and verify flan-t5-small is correctly reported as not tool-calling-enabled
+9. Verify no false positives or false negatives in the audit report
+
+**Expected Results**:
+- Validated models correctly display the "Tool Calling Enabled" tag
+- Non-validated models do not display the tag
+- Audit process confirms consistency between UI tags and catalog metadata
+- Audit report is accurate with no false positives or negatives
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-E2E-003.md
+++ b/tool_calling_model_catalog/test_cases/TC-E2E-003.md
@@ -1,0 +1,39 @@
+---
+test_case_id: TC-E2E-003
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-E2E-003: Catalog discovery and modelcard viewing flow
+
+**Objective**: Validate the end-to-end user journey of discovering tool-calling models in the catalog using the filter, then viewing detailed tool-calling information on the modelcard.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- Multiple models ingested: at least 3 tool-calling-enabled and 3 non-tool-calling models
+
+**Test Steps**:
+1. Navigate to the RHOAI Model Catalog UI as a data scientist user
+2. Verify the catalog displays all models (tool-calling and non-tool-calling)
+3. Click the 'Tool Calling' filter in the left navigation menu
+4. Verify only tool-calling-enabled models are shown (3 models)
+5. Click on granite-3.1-8b-instruct to open its modelcard
+6. Verify the modelcard shows YAML frontmatter with tool-calling commands:
+   - `tool_call_parser: hermes`
+   - `chat_template_path: examples/tool_chat_template_granite.jinja`
+   - `--enable-auto-tool-choice` flag information
+7. Copy the CLI arguments from the modelcard
+8. Verify the copied text is clean and usable
+9. Navigate back to the filtered catalog list
+10. Verify the filter state is preserved (still showing only tool-calling models)
+11. Click on llama-3.3-70b-instruct and verify its modelcard shows different tool-calling parameters (parser: llama3_json)
+
+**Expected Results**:
+- Filter correctly narrows the catalog to tool-calling models
+- Modelcards display complete, model-specific tool-calling information
+- Navigation between filtered list and modelcards preserves filter state
+- Different models show their own unique tool-calling parameters
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-E2E-004.md
+++ b/tool_calling_model_catalog/test_cases/TC-E2E-004.md
@@ -1,0 +1,39 @@
+---
+test_case_id: TC-E2E-004
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-E2E-004: Schema backwards compatibility with existing models
+
+**Objective**: Validate that the schema enhancement for tool-calling metadata does not break the end-to-end experience for pre-existing models in the catalog, ensuring backwards compatibility across ingestion, API, and UI.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog fully deployed
+- Pre-existing models in the catalog that were ingested before the tool-calling schema update
+- New tool-calling models also ingested
+
+**Test Steps**:
+1. Query the BFF API for a pre-existing model (e.g., flan-t5-small)
+2. Verify the response is valid JSON with all original fields intact
+3. Verify tool-calling fields are null/absent (not populated with defaults)
+4. Navigate to the Catalog UI and view the pre-existing model's catalog listing
+5. Verify the model does NOT show a "Tool Calling Enabled" tag
+6. Open the modelcard and verify it renders without errors
+7. Apply the 'Tool Calling' filter
+8. Verify the pre-existing model is excluded from filtered results
+9. Clear the filter and verify the pre-existing model reappears
+10. Query the BFF API for a new tool-calling model (granite-3.1-8b-instruct)
+11. Verify the response includes all tool-calling fields
+12. Verify both models coexist in the catalog without conflicts
+
+**Expected Results**:
+- Pre-existing models continue to function identically to before the schema update
+- New tool-calling models work correctly alongside legacy models
+- API responses are backwards compatible
+- UI rendering is correct for both model types
+- Filters correctly differentiate between model types
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-FILTER-001.md
+++ b/tool_calling_model_catalog/test_cases/TC-FILTER-001.md
@@ -1,0 +1,29 @@
+---
+test_case_id: TC-FILTER-001
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-FILTER-001: 'Tool Calling' task filter visible in left navigation menu
+
+**Objective**: Verify that the 'Tool Calling' task filter appears as a selectable option in the left-hand navigation menu of the RHOAI Model Catalog UI.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- At least one tool-calling-enabled model ingested into the catalog
+
+**Test Steps**:
+1. Navigate to the RHOAI Model Catalog UI in a browser
+2. Locate the left-hand navigation panel with task filters
+3. Verify a 'Tool Calling' option is present in the task filter list
+4. Verify the filter is positioned appropriately among other task filters
+5. Verify the filter displays a model count badge or indicator showing the number of tool-calling models available
+
+**Expected Results**:
+- 'Tool Calling' filter is visible and selectable in the left navigation
+- Filter label is clearly readable and distinguishable from other task filters
+- Filter shows correct count of tool-calling enabled models
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-FILTER-002.md
+++ b/tool_calling_model_catalog/test_cases/TC-FILTER-002.md
@@ -1,0 +1,31 @@
+---
+test_case_id: TC-FILTER-002
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-FILTER-002: Filter returns only tool-calling-enabled models
+
+**Objective**: Verify that selecting the 'Tool Calling' filter in the catalog UI displays only models that have `tool_calling_supported: true` with validated metadata.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- Catalog contains a mix of tool-calling-enabled and non-tool-calling models (at least 3 of each)
+
+**Test Steps**:
+1. Navigate to the RHOAI Model Catalog UI
+2. Note the total number of models displayed (should include both types)
+3. Click the 'Tool Calling' filter in the left navigation
+4. Verify the model list is filtered to show only tool-calling-enabled models
+5. Verify each displayed model has a "Tool Calling" tag or indicator
+6. Verify the count matches the number of models ingested with `tool_calling_supported: true`
+7. Verify no models without tool-calling support appear in the filtered results
+
+**Expected Results**:
+- Only tool-calling-enabled models are displayed after filtering
+- Model count is correct and matches the database count
+- Non-tool-calling models are excluded from the filtered view
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-FILTER-003.md
+++ b/tool_calling_model_catalog/test_cases/TC-FILTER-003.md
@@ -1,0 +1,33 @@
+---
+test_case_id: TC-FILTER-003
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-FILTER-003: Tool Calling filter combined with existing task filters
+
+**Objective**: Verify that the 'Tool Calling' filter works correctly when combined with other existing task filters in the catalog UI.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- Catalog contains models with various task tags and some with tool-calling support
+
+**Test Steps**:
+1. Navigate to the RHOAI Model Catalog UI
+2. Apply the 'Tool Calling' filter
+3. Note the filtered model count
+4. Apply an additional existing task filter (e.g., 'Text Generation')
+5. Verify the results show only models matching BOTH filters (intersection)
+6. Remove the 'Tool Calling' filter while keeping the other filter
+7. Verify the results update to show all models matching only the remaining filter
+8. Re-apply 'Tool Calling' and verify the combined results are consistent
+
+**Expected Results**:
+- Filters compose using AND logic (intersection of results)
+- Combined filter count is less than or equal to either individual filter count
+- Removing one filter correctly expands results to match the remaining filter
+- No UI errors or inconsistent states when toggling filters
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-FILTER-004.md
+++ b/tool_calling_model_catalog/test_cases/TC-FILTER-004.md
@@ -1,0 +1,30 @@
+---
+test_case_id: TC-FILTER-004
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-FILTER-004: Tool Calling filter shows correct model count
+
+**Objective**: Verify that the model count displayed alongside the 'Tool Calling' filter accurately reflects the number of tool-calling-enabled models in the catalog.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- Known quantity of tool-calling-enabled models ingested (e.g., 3 models)
+
+**Test Steps**:
+1. Navigate to the RHOAI Model Catalog UI
+2. Check the model count badge next to the 'Tool Calling' filter in the left navigation
+3. Verify the count matches the known number of ingested tool-calling models (3)
+4. Ingest one additional tool-calling model
+5. Refresh the catalog UI
+6. Verify the count badge updates to reflect the new total (4)
+
+**Expected Results**:
+- Count badge accurately reflects the current number of tool-calling-enabled models
+- Count updates when new models are ingested
+- Count does not include models where `tool_calling_supported` is `false` or `null`
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-FILTER-005.md
+++ b/tool_calling_model_catalog/test_cases/TC-FILTER-005.md
@@ -1,0 +1,29 @@
+---
+test_case_id: TC-FILTER-005
+strat_key: RHAISTRAT-1262
+priority: P2
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-FILTER-005: Tool Calling filter with no matching models displays empty state
+
+**Objective**: Verify that the 'Tool Calling' filter handles the case where no tool-calling-enabled models exist in the catalog, displaying an appropriate empty state.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- No models with `tool_calling_supported: true` in the catalog (or all such models removed)
+
+**Test Steps**:
+1. Navigate to the RHOAI Model Catalog UI
+2. Verify the 'Tool Calling' filter shows a count of 0 (or is hidden if designed to hide when empty)
+3. If the filter is visible, click it
+4. Verify an appropriate empty state message is displayed (e.g., "No models available for this filter")
+5. Verify no error messages or broken UI elements appear
+
+**Expected Results**:
+- Empty state is handled gracefully with a user-friendly message
+- No JavaScript errors or broken layouts
+- User can easily navigate back or clear the filter
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-INGEST-001.md
+++ b/tool_calling_model_catalog/test_cases/TC-INGEST-001.md
@@ -1,0 +1,48 @@
+---
+test_case_id: TC-INGEST-001
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-INGEST-001: Ingest single validated model with complete tool-calling metadata
+
+**Objective**: Verify that a single validated model with all tool-calling metadata fields can be successfully ingested into the Model Catalog.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog deployed
+- Model Validation team output available (or synthetic test data conforming to schema)
+
+**Test Steps**:
+1. Prepare a model metadata payload with all required tool-calling fields populated
+2. Submit the model entry to the ingestion pipeline
+3. Verify the ingestion completes without errors
+4. Query the Model Catalog database to confirm the model entry exists
+5. Verify all tool-calling fields are stored with correct values
+
+**Expected Results**:
+- Model entry is created in the catalog with status indicating successful ingestion
+- All five tool-calling fields are populated and match the submitted values
+- Model is visible in the catalog after ingestion
+
+**Test Data**:
+```yaml
+model_id: granite-3.1-8b-instruct
+model_name: Granite 3.1 8B Instruct
+tool_calling_supported: true
+required_cli_args:
+  - "--max-model-len"
+  - "8192"
+  - "--dtype"
+  - "float16"
+chat_template_path: "examples/tool_chat_template_granite.jinja"
+chat_template_file_name: "tool_chat_template_granite.jinja"
+tool_call_parser: "hermes"
+```
+
+**Validation**:
+- Database query confirms all fields match the submitted payload
+- BFF API returns the model with correct metadata
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-INGEST-002.md
+++ b/tool_calling_model_catalog/test_cases/TC-INGEST-002.md
@@ -1,0 +1,60 @@
+---
+test_case_id: TC-INGEST-002
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-INGEST-002: Ingest batch of validated tool-calling models from RHAISTRAT-1165
+
+**Objective**: Verify that a batch of validated tool-calling models (minimum 3) from the RHAISTRAT-1165 initiative can be ingested together with correct metadata and proper tags.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog deployed
+- Batch of at least 3 validated model entries ready for ingestion
+
+**Test Steps**:
+1. Prepare a batch payload containing 3 validated models with different tool_call_parser values
+2. Submit the batch to the ingestion pipeline
+3. Verify all 3 models are successfully ingested without errors
+4. Query the catalog and verify each model has correct tool-calling metadata
+5. Verify each model has the appropriate tags applied (including "Tool Calling" tag)
+
+**Expected Results**:
+- All 3 models are ingested in a single batch operation
+- Each model retains its distinct tool_call_parser, chat_template_path, and required_cli_args
+- No cross-contamination of metadata between models
+- All models are tagged correctly for UI filtering
+
+**Test Data**:
+```json
+[
+  {
+    "model_id": "granite-3.1-8b-instruct",
+    "tool_calling_supported": true,
+    "tool_call_parser": "hermes",
+    "chat_template_file_name": "tool_chat_template_granite.jinja",
+    "chat_template_path": "examples/tool_chat_template_granite.jinja",
+    "required_cli_args": ["--max-model-len", "8192"]
+  },
+  {
+    "model_id": "llama-3.3-70b-instruct",
+    "tool_calling_supported": true,
+    "tool_call_parser": "llama3_json",
+    "chat_template_file_name": "tool_chat_template_llama3.3_json.jinja",
+    "chat_template_path": "examples/tool_chat_template_llama3.3_json.jinja",
+    "required_cli_args": ["--max-model-len", "16384", "--dtype", "bfloat16"]
+  },
+  {
+    "model_id": "mistral-7b-instruct-v0.3",
+    "tool_calling_supported": true,
+    "tool_call_parser": "mistral",
+    "chat_template_file_name": "tool_chat_template_mistral.jinja",
+    "chat_template_path": "examples/tool_chat_template_mistral.jinja",
+    "required_cli_args": ["--max-model-len", "32768"]
+  }
+]
+```
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-INGEST-003.md
+++ b/tool_calling_model_catalog/test_cases/TC-INGEST-003.md
@@ -1,0 +1,29 @@
+---
+test_case_id: TC-INGEST-003
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-INGEST-003: Verify ingested model tagged under 'Other model' category
+
+**Objective**: Verify that a tool-calling model ingested into the catalog is correctly categorized under 'Other model' and tagged with the appropriate tool-calling tag.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog deployed
+- At least one model successfully ingested with `tool_calling_supported: true`
+
+**Test Steps**:
+1. Ingest a validated tool-calling model into the Model Catalog
+2. Query the catalog for the model's category assignment
+3. Verify the model is categorized under 'Other model'
+4. Verify the model has a "Tool Calling" tag or equivalent label applied
+5. Access the RHOAI Catalog UI and confirm the model appears under the 'Other model' section
+
+**Expected Results**:
+- Model is categorized under 'Other model' category as specified in the strategy
+- Tool-calling tag is applied to the model entry
+- Model is discoverable in the UI under the correct category
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-INGEST-004.md
+++ b/tool_calling_model_catalog/test_cases/TC-INGEST-004.md
@@ -1,0 +1,43 @@
+---
+test_case_id: TC-INGEST-004
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-INGEST-004: Update tool-calling metadata for previously ingested model
+
+**Objective**: Verify that tool-calling metadata can be updated for a model that was previously ingested, reflecting new CLI requirements from the Model Validation team.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog deployed
+- A model previously ingested with initial tool-calling metadata
+
+**Test Steps**:
+1. Confirm the existing model entry has its original tool-calling metadata (e.g., `tool_call_parser: "hermes"`)
+2. Submit an update to the model's tool-calling metadata with revised values:
+   - Change `tool_call_parser` from `"hermes"` to `"granite"`
+   - Add a new CLI argument `"--enforce-eager"` to `required_cli_args`
+   - Update `chat_template_path` to a new template version
+3. Verify the update completes without errors
+4. Query the catalog and confirm all updated fields reflect the new values
+5. Verify the model's non-tool-calling metadata (name, description, existing tags) is unchanged
+
+**Expected Results**:
+- Updated metadata replaces previous values without creating a duplicate entry
+- Non-tool-calling fields are not affected by the update
+- BFF API returns the updated metadata immediately after the update
+
+**Test Data**:
+```json
+{
+  "model_id": "granite-3.1-8b-instruct",
+  "tool_call_parser": "granite",
+  "required_cli_args": ["--max-model-len", "8192", "--dtype", "float16", "--enforce-eager"],
+  "chat_template_path": "examples/tool_chat_template_granite_v2.jinja",
+  "chat_template_file_name": "tool_chat_template_granite_v2.jinja"
+}
+```
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-INGEST-005.md
+++ b/tool_calling_model_catalog/test_cases/TC-INGEST-005.md
@@ -1,0 +1,36 @@
+---
+test_case_id: TC-INGEST-005
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-INGEST-005: Ingest model with partial tool-calling metadata
+
+**Objective**: Verify the ingestion pipeline's behavior when a model is submitted with only some tool-calling fields populated (e.g., tool_calling_supported is true but chat_template_path is missing).
+
+**Test Steps**:
+1. Prepare a model metadata payload with `tool_calling_supported: true` but `chat_template_path` and `chat_template_file_name` omitted
+2. Submit the model to the ingestion pipeline
+3. Observe whether the ingestion succeeds with a warning or is rejected with a validation error
+4. If accepted, verify the model entry in the database has null values for the missing fields
+5. If rejected, verify the error message identifies the missing required fields
+
+**Expected Results**:
+- The ingestion pipeline either:
+  - Accepts the partial entry with warnings and stores null for missing fields, OR
+  - Rejects the entry with a clear validation error listing missing required fields
+- In either case, no partial or corrupted data is written to the catalog
+
+**Test Data**:
+```json
+{
+  "model_id": "granite-3.0-2b-instruct",
+  "tool_calling_supported": true,
+  "required_cli_args": ["--max-model-len", "4096"],
+  "tool_call_parser": "hermes"
+}
+```
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-INGEST-006.md
+++ b/tool_calling_model_catalog/test_cases/TC-INGEST-006.md
@@ -1,0 +1,27 @@
+---
+test_case_id: TC-INGEST-006
+strat_key: RHAISTRAT-1262
+priority: P2
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-INGEST-006: Reject ingestion of model with malformed metadata
+
+**Objective**: Verify that the ingestion pipeline rejects a model entry with malformed or invalid tool-calling metadata and provides a meaningful error.
+
+**Test Steps**:
+1. Submit a model entry with malformed YAML frontmatter (e.g., invalid indentation, unclosed quotes)
+2. Verify the ingestion is rejected with a parsing error
+3. Submit a model entry with a `chat_template_path` containing invalid characters (e.g., `../../etc/passwd`)
+4. Verify the ingestion is rejected or the path is sanitized
+5. Submit a model entry with `required_cli_args` containing an extremely long string (10,000+ characters)
+6. Verify the ingestion handles the boundary case appropriately
+
+**Expected Results**:
+- Malformed metadata is rejected with descriptive error messages
+- Path traversal attempts in template paths are blocked
+- Oversized field values are rejected or truncated with a warning
+- No partial data is written to the catalog from rejected entries
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-REG-001.md
+++ b/tool_calling_model_catalog/test_cases/TC-REG-001.md
@@ -1,0 +1,32 @@
+---
+test_case_id: TC-REG-001
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-REG-001: Existing model search functionality unaffected by schema update
+
+**Objective**: Verify that the Model Catalog search functionality continues to work correctly for all models after the tool-calling schema enhancement.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog deployed
+- Catalog contains both pre-existing models and newly ingested tool-calling models
+
+**Test Steps**:
+1. Search for a pre-existing model by name (e.g., "flan-t5-small") using the catalog search
+2. Verify the search returns the correct result
+3. Search for a tool-calling model by name (e.g., "granite-3.1-8b-instruct")
+4. Verify the search returns the correct result with tool-calling metadata
+5. Search using a partial name match (e.g., "granite")
+6. Verify all matching models are returned regardless of tool-calling status
+7. Search for a non-existent model
+8. Verify the search returns an empty result without errors
+
+**Expected Results**:
+- Search results are accurate for both legacy and new models
+- No performance degradation in search after schema update
+- Search does not inadvertently filter by tool-calling status
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-REG-002.md
+++ b/tool_calling_model_catalog/test_cases/TC-REG-002.md
@@ -1,0 +1,33 @@
+---
+test_case_id: TC-REG-002
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-REG-002: Existing task filters operational after adding Tool Calling filter
+
+**Objective**: Verify that all pre-existing task filters in the catalog left navigation continue to function correctly after the 'Tool Calling' filter is added.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- Catalog contains models with various task assignments
+
+**Test Steps**:
+1. Navigate to the RHOAI Model Catalog UI
+2. Identify all existing task filters in the left navigation (e.g., Text Generation, Text Classification, etc.)
+3. Apply each existing filter one by one
+4. Verify each filter returns the correct set of models
+5. Verify filter counts match the actual number of models with each task
+6. Verify the new 'Tool Calling' filter does not interfere with existing filters
+7. Apply an existing filter and the 'Tool Calling' filter simultaneously
+8. Verify the combined results are correct (intersection)
+
+**Expected Results**:
+- All pre-existing filters continue to work as before
+- Filter counts are accurate
+- No interference between the new 'Tool Calling' filter and existing filters
+- UI layout is not broken by the addition of the new filter
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-REG-003.md
+++ b/tool_calling_model_catalog/test_cases/TC-REG-003.md
@@ -1,0 +1,31 @@
+---
+test_case_id: TC-REG-003
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-REG-003: Existing modelcard display unaffected by schema changes
+
+**Objective**: Verify that modelcards for pre-existing models (without tool-calling metadata) continue to render correctly after the schema update.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with RHOAI Catalog UI deployed
+- Pre-existing models in the catalog that were ingested before the tool-calling schema update
+
+**Test Steps**:
+1. Navigate to the modelcard for a pre-existing model (e.g., flan-t5-small)
+2. Verify all existing sections render correctly (description, tags, model details)
+3. Verify no empty or broken tool-calling sections appear
+4. Verify no "undefined", "null", or error indicators for tool-calling fields
+5. Compare the modelcard layout with the expected layout from before the schema update
+6. Check the browser console for any JavaScript errors during rendering
+
+**Expected Results**:
+- Pre-existing modelcards render identically to before the schema update
+- No visual artifacts from missing tool-calling fields
+- No JavaScript errors in the browser console
+- Model metadata is intact and correctly displayed
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-REG-004.md
+++ b/tool_calling_model_catalog/test_cases/TC-REG-004.md
@@ -1,0 +1,30 @@
+---
+test_case_id: TC-REG-004
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-REG-004: Existing BFF API responses for non-tool-calling models unchanged
+
+**Objective**: Verify that the BFF API continues to return correct, well-formed responses for pre-existing models that do not have tool-calling metadata.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog BFF API deployed
+- Pre-existing models in the catalog without tool-calling metadata
+
+**Test Steps**:
+1. Send a GET request to the BFF API for a pre-existing non-tool-calling model
+2. Verify the HTTP response status is 200 OK
+3. Verify the response JSON structure matches the expected schema for non-tool-calling models
+4. Verify existing fields (model_id, name, description, tags) are present and correct
+5. Verify the response does not include unexpected tool-calling fields with default values
+6. Compare the response structure with the documented API contract from before the schema update
+
+**Expected Results**:
+- API response for legacy models is unchanged in structure and content
+- No new required fields break existing API consumers
+- Response is backwards compatible with existing Serving UI code
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-SCHEMA-001.md
+++ b/tool_calling_model_catalog/test_cases/TC-SCHEMA-001.md
@@ -1,0 +1,33 @@
+---
+test_case_id: TC-SCHEMA-001
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-SCHEMA-001: Store tool_calling_supported boolean field in Model Catalog
+
+**Objective**: Verify that the Model Catalog schema correctly stores and retrieves the `tool_calling_supported` boolean field for a model entry.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog database deployed and accessible
+- Database schema migration applied with tool-calling fields
+
+**Test Steps**:
+1. Insert a model entry with `tool_calling_supported: true` into the Model Catalog database
+2. Query the database to retrieve the stored value for the model entry
+3. Verify the field value is `true` (boolean, not string)
+4. Insert a second model entry with `tool_calling_supported: false`
+5. Query the database and verify the field value is `false`
+
+**Expected Results**:
+- The `tool_calling_supported` field is persisted as a boolean type
+- `true` and `false` values are stored and retrieved without type coercion issues
+- No database errors on insert or query
+
+**Validation**:
+- Direct database query confirms field type is boolean
+- `SELECT tool_calling_supported FROM model_catalog WHERE model_id = '<model_id>'` returns the correct boolean value
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-SCHEMA-002.md
+++ b/tool_calling_model_catalog/test_cases/TC-SCHEMA-002.md
@@ -1,0 +1,44 @@
+---
+test_case_id: TC-SCHEMA-002
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-SCHEMA-002: Store required_cli_args list field in Model Catalog
+
+**Objective**: Verify that the Model Catalog schema correctly stores and retrieves the `required_cli_args` list field containing CLI arguments needed to run a model.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog database deployed and accessible
+- Database schema migration applied with tool-calling fields
+
+**Test Steps**:
+1. Insert a model entry with the following `required_cli_args` list:
+   ```json
+   ["--max-model-len", "8192", "--dtype", "float16"]
+   ```
+2. Query the database to retrieve the stored `required_cli_args` for the model
+3. Verify the returned value is a list with 4 elements in the correct order
+4. Verify each element is preserved as a string
+
+**Expected Results**:
+- The `required_cli_args` field is stored as a list/array type
+- All list elements are preserved in order without truncation
+- String values within the list are not modified or escaped
+
+**Test Data**:
+```json
+{
+  "model_id": "granite-3.1-8b-instruct",
+  "tool_calling_supported": true,
+  "required_cli_args": ["--max-model-len", "8192", "--dtype", "float16"]
+}
+```
+
+**Validation**:
+- Direct database query confirms the list contains exactly 4 elements
+- JSON array roundtrip preserves order and values
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-SCHEMA-003.md
+++ b/tool_calling_model_catalog/test_cases/TC-SCHEMA-003.md
@@ -1,0 +1,42 @@
+---
+test_case_id: TC-SCHEMA-003
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-SCHEMA-003: Store chat_template_path and chat_template_file_name fields
+
+**Objective**: Verify that the Model Catalog schema correctly stores and retrieves both `chat_template_path` and `chat_template_file_name` string fields for upstream and downstream template locations.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog database deployed and accessible
+- Database schema migration applied with tool-calling fields
+
+**Test Steps**:
+1. Insert a model entry with upstream chat template values:
+   ```json
+   {
+     "chat_template_path": "examples/tool_chat_template_granite.jinja",
+     "chat_template_file_name": "tool_chat_template_granite.jinja"
+   }
+   ```
+2. Query the database and verify both fields are stored correctly
+3. Insert a second model entry with downstream chat template values:
+   ```json
+   {
+     "chat_template_path": "opt/app-root/template/tool_chat_template_granite.jinja",
+     "chat_template_file_name": "tool_chat_template_granite.jinja"
+   }
+   ```
+4. Query and verify the downstream path is stored correctly
+5. Verify both entries can coexist with different `chat_template_path` values but the same `chat_template_file_name`
+
+**Expected Results**:
+- Both `chat_template_path` and `chat_template_file_name` are stored as strings
+- Upstream path format (`examples/<filename>`) is preserved
+- Downstream path format (`opt/app-root/template/<filename>`) is preserved
+- File name is consistent across path formats
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-SCHEMA-004.md
+++ b/tool_calling_model_catalog/test_cases/TC-SCHEMA-004.md
@@ -1,0 +1,39 @@
+---
+test_case_id: TC-SCHEMA-004
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-SCHEMA-004: Store tool_call_parser string field in Model Catalog
+
+**Objective**: Verify that the Model Catalog schema correctly stores and retrieves the `tool_call_parser` string field identifying the parser type for tool calling.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog database deployed and accessible
+- Database schema migration applied with tool-calling fields
+
+**Test Steps**:
+1. Insert a model entry with `tool_call_parser: "hermes"` for a Granite model
+2. Query the database and verify the value is stored as `"hermes"`
+3. Insert a second model entry with `tool_call_parser: "llama3_json"` for a Llama model
+4. Query and verify the value is stored as `"llama3_json"`
+5. Insert a third model entry with `tool_call_parser: "mistral"` for a Mistral model
+6. Query and verify all three parser values are retrievable
+
+**Expected Results**:
+- The `tool_call_parser` field is stored as a string
+- Different parser values (`hermes`, `llama3_json`, `mistral`) are all accepted
+- No validation errors on storage or retrieval
+
+**Test Data**:
+```json
+[
+  {"model_id": "granite-3.1-8b-instruct", "tool_call_parser": "hermes"},
+  {"model_id": "llama-3.3-70b-instruct", "tool_call_parser": "llama3_json"},
+  {"model_id": "mistral-7b-instruct-v0.3", "tool_call_parser": "mistral"}
+]
+```
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-SCHEMA-005.md
+++ b/tool_calling_model_catalog/test_cases/TC-SCHEMA-005.md
@@ -1,0 +1,31 @@
+---
+test_case_id: TC-SCHEMA-005
+strat_key: RHAISTRAT-1262
+priority: P0
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-SCHEMA-005: Existing models without tool-calling fields remain functional after schema update
+
+**Objective**: Verify that models ingested before the tool-calling schema enhancement continue to function correctly, with tool-calling fields defaulting to null or empty values.
+
+**Preconditions**:
+- RHOAI 3.4 cluster with Model Catalog containing pre-existing models ingested before schema update
+- Database schema migration applied with tool-calling fields
+
+**Test Steps**:
+1. Identify an existing model in the catalog that was ingested before the tool-calling schema update (e.g., a text-generation model without tool-calling support)
+2. Query the database for the model's full record including new tool-calling fields
+3. Verify that `tool_calling_supported` is `null` or `false` (not an error)
+4. Verify that `required_cli_args`, `chat_template_path`, `chat_template_file_name`, and `tool_call_parser` are `null` or empty
+5. Verify the model's existing fields (summary, description, tags, task) remain unchanged
+6. Access the model via the BFF API and verify the response is valid JSON without errors
+
+**Expected Results**:
+- Pre-existing models are not broken by the schema migration
+- New tool-calling fields default to safe null/empty values
+- No data corruption or loss of existing metadata
+- API responses for legacy models remain well-formed
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-SCHEMA-006.md
+++ b/tool_calling_model_catalog/test_cases/TC-SCHEMA-006.md
@@ -1,0 +1,36 @@
+---
+test_case_id: TC-SCHEMA-006
+strat_key: RHAISTRAT-1262
+priority: P1
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-SCHEMA-006: Schema handles empty required_cli_args list
+
+**Objective**: Verify that the Model Catalog schema correctly handles a model entry with an empty `required_cli_args` list, representing a model that requires no special CLI arguments to run.
+
+**Test Steps**:
+1. Insert a model entry with `tool_calling_supported: true` and `required_cli_args: []` (empty list)
+2. Query the database and verify `required_cli_args` is stored as an empty list (not null)
+3. Retrieve the model via the BFF API
+4. Verify the API response includes `required_cli_args` as an empty array `[]`, not omitted or null
+
+**Expected Results**:
+- Empty list `[]` is distinct from `null` in storage
+- API response correctly reflects the empty list
+- No errors during storage or retrieval
+
+**Test Data**:
+```json
+{
+  "model_id": "granite-3.1-2b-instruct",
+  "tool_calling_supported": true,
+  "required_cli_args": [],
+  "tool_call_parser": "hermes",
+  "chat_template_path": "examples/tool_chat_template_granite_2b.jinja",
+  "chat_template_file_name": "tool_chat_template_granite_2b.jinja"
+}
+```
+
+**Notes**: To be filled later in the process.

--- a/tool_calling_model_catalog/test_cases/TC-SCHEMA-007.md
+++ b/tool_calling_model_catalog/test_cases/TC-SCHEMA-007.md
@@ -1,0 +1,26 @@
+---
+test_case_id: TC-SCHEMA-007
+strat_key: RHAISTRAT-1262
+priority: P2
+status: Draft
+automation_status: Not Started
+last_updated: '2026-04-13'
+---
+# TC-SCHEMA-007: Schema rejects invalid field types for tool-calling metadata
+
+**Objective**: Verify that the Model Catalog schema rejects or handles gracefully when tool-calling fields receive values of incorrect types.
+
+**Test Steps**:
+1. Attempt to insert a model entry with `tool_calling_supported: "yes"` (string instead of boolean)
+2. Verify the insertion is rejected with a validation error or the value is not accepted
+3. Attempt to insert a model entry with `required_cli_args: "--max-model-len 8192"` (string instead of list)
+4. Verify the insertion is rejected or handled gracefully
+5. Attempt to insert a model entry with `tool_call_parser: 12345` (integer instead of string)
+6. Verify the insertion is rejected or handled gracefully
+
+**Expected Results**:
+- Invalid type inputs are rejected with descriptive error messages
+- No partial writes that could leave the database in an inconsistent state
+- Valid entries in the same batch are not affected by invalid entries
+
+**Notes**: To be filled later in the process.


### PR DESCRIPTION
## Test Plan: Tool Calling Metadata Integration

**Strategy**: [RHAISTRAT-1262](https://redhat.atlassian.net/browse/RHAISTRAT-1262)
**Version**: 1.0.0

### Summary
This test plan covers the integration of validated Tool Calling metadata into the Model Catalog. This feature enables the Model Catalog to serve as the single source of truth for the RHOAI Serving UI and downstream deployment automation by storing validated CLI requirements and chat template paths for tool-calling models.

### Scope
- Schema enhancement to store tool-calling CLI arguments and chat template paths
- Ingestion pipeline to receive and update model entries with validation team's output
- API exposure via Model Catalog BFF to provide tool-calling attributes in structured JSON format
- UI integration: adding 'Tool Calling' task filter to left navigation menu
- Tool-calling data display within modelcards for supported models
- Tagging models with "Tool Calling Enabled" backed by validated Catalog entries
- Metadata fields: tool_calling_supported, required_cli_args, chat_template_file_name, chat_template_path, tool_call_parser
- Sample validated models from initiative RHAISTRAT-1165

### Test Objectives
1. Verify the Model Catalog database successfully stores all required tool-calling metadata fields
2. Confirm the ingestion pipeline correctly processes validated model data
3. Validate the Model Catalog BFF API returns tool-calling metadata in structured JSON format
4. Verify the 'Tool Calling' task appears in the UI's left navigation filter
5. Confirm modelcards display tool-calling CLI arguments and chat template paths
6. Ensure models tagged as "Tool Calling Enabled" have corresponding validated entries
7. Validate versioning support across RHAIIS and ModelCar image updates

### Artifacts
- TestPlan.md
- TestPlanGaps.md
- test_cases/INDEX.md (28 test cases)