### PR TITLE
improve ui_assert screenshot quality and code clarity

### DIFF
--- a/.claude/skills/test-plan.ui-verify/instructions.md
+++ b/.claude/skills/test-plan.ui-verify/instructions.md
@@ -88,6 +88,8 @@ python3 <SKILL_DIR>/scripts/ui_assert.py \
   --screenshot verify-<short-description>
 ```
 
+Always highlight the verified element inside `--js` by setting `el.style.outline='3px solid green'` (PASS) or `'3px solid red'` (FAIL) on the found element before returning the verdict. This records what was actually checked in the screenshot without closing open overlays — a style change on an existing element does not trigger mutation observers. The outline is automatically removed by the cleanup step. Only use `--selector` for static page elements where a pointer label is also wanted.
+
 Always pass `--title` using `tc["title"]` from the context — it is stored in the report log so that `report.html` shows real TC names instead of just IDs.
 
 **For ephemeral UI state** (dropdowns, menus, accordions that close between tool calls), use `--click-before` to open the container and assert its contents in one atomic call. Always pair it with `--retry 1` — if the container was already open and the click toggled it closed, the retry re-clicks to reopen it. Never open with a separate `ui_interact.py click` and assert in the next call — the container will be closed by then:
@@ -119,6 +121,8 @@ python3 <SKILL_DIR>/scripts/ui_assert.py --tc <TC_ID> --title "..." \
   --retry 2 \
   --what "..." --expected "..." --js "() => ..." --screenshot verify-<desc>
 ```
+
+**When the expected value depends on the environment** (URL hostname, resource ID, cluster-specific name), always run `--inspect` first to read the actual current value, then write the assertion from what you observe. Never assume a value from a TC description — names used in TCs (route names, service names, pattern labels) often do not appear literally in the running system's URLs or DOM.
 
 **When checking an element's attribute** (href, text, state), always find the element first and then read its value — never search for elements that already contain the target value. An element exists regardless of what value it currently holds; searching only for the new value misses the case where it exists with the old value and produces a misleading "not found" failure. See `js-patterns.md` for the correct pattern.
 

--- a/.claude/skills/test-plan.ui-verify/js-patterns.md
+++ b/.claude/skills/test-plan.ui-verify/js-patterns.md
@@ -70,6 +70,22 @@ Body text always contains option panels regardless of whether an option is appli
 
 ---
 
+## Visual highlight in screenshots
+
+To mark what was actually verified in the screenshot, apply a CSS outline to the found element **inside the `--js` function** as a side effect. This works for all assertions — including dropdowns and menus — because a style-attribute change on an existing element does not trigger DOM mutation observers and will not close open overlays. The outline is automatically removed by the cleanup step.
+
+```js
+// Highlight found element green (PASS), red (FAIL) — picked up in screenshot
+"() => { const el=document.querySelector('<selector>'); if(!el) return 'FAIL:not found'; el.style.outline='3px solid green'; return 'PASS:'+el.textContent.trim(); }"
+
+// Highlight the element that contains the wrong value so it's visible in the FAIL screenshot
+"() => { const el=document.querySelector('<selector>'); if(!el) return 'FAIL:not found'; const val=el.getAttribute('<attr>'); if(val.includes('<wrong>')) { el.style.outline='3px solid red'; return 'FAIL:'+val; } el.style.outline='3px solid green'; return 'PASS:'+val; }"
+```
+
+Use `--selector` (the external argument) only for static elements on regular pages where you want a pointer label alongside the outline. For ephemeral UI (dropdowns, menus), always use the JS-inline approach — `--selector` appends a DOM node which closes the overlay before the screenshot fires.
+
+---
+
 ## Checking an element's attribute value (href, text, state)
 
 Always **find the element first, then read its value**. Never search only for elements that already carry the target value — the element exists regardless of its current state, and a selector that requires the new value returns null when the old value is present, producing a misleading "not found" failure.

--- a/.claude/skills/test-plan.ui-verify/scripts/github_utils.py
+++ b/.claude/skills/test-plan.ui-verify/scripts/github_utils.py
@@ -13,8 +13,8 @@ import yaml
 from helpers import matches_tc_filter as _matches_tc_filter
 
 
-def _run(cmd):
-    return subprocess.run(cmd, capture_output=True, text=True)
+def _run(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
 
 
 def fetch_file(repo: str, path: str, ref: str) -> str | None:

--- a/.claude/skills/test-plan.ui-verify/scripts/ui_assert.py
+++ b/.claude/skills/test-plan.ui-verify/scripts/ui_assert.py
@@ -99,63 +99,81 @@ def update_log(tc_id: str, what: str, expected: str, result: str, detail: str,
     TC_LOG.write_text(json.dumps(log, indent=2))
 
 
-def _click_before(page, description: str) -> bool:
-    """Click an element to open ephemeral UI state (dropdown, menu, accordion) before asserting.
+def _wait_animations(page) -> None:
+    """Wait for all non-infinite CSS animations/transitions to finish.
 
-    Mirrors the tier strategy of do_click in ui_interact.py so behaviour is consistent.
-    Returns True to continue with the assertion, False if the click caused unintended
-    navigation (caller should return exit 2 / WRONG_PAGE in that case).
-
-    If the element is not found the function still returns True — the JS assertion
-    that follows will FAIL with the real reason, which is the correct logged outcome.
+    Adapts to actual animation duration — not a fixed delay. Infinite animations
+    (spinners, pulses) are excluded. Uses Playwright's page-default timeout as
+    safety net; falls through silently on timeout.
     """
-    from urllib.parse import urlparse
-    url_before = page.url
-    clicked = False
+    try:
+        page.wait_for_function(
+            "() => !document.getAnimations().filter("
+            "  a => a.playState === 'running'"
+            "    && a.effect && a.effect.getTiming().iterations !== Infinity"
+            ").length"
+        )
+    except Exception:
+        pass
 
-    # Tier 1: Playwright role-based — exact match first, then partial (same order as do_click)
+
+def _click_element(page, description: str) -> str | None:
+    """Try to click an element matching description. Returns a label string on success, None otherwise.
+
+    Tier 1: Playwright role-based (exact then partial).
+    Tier 2: JS text / aria-label scan.
+    """
     for exact in (True, False):
-        if clicked:
-            break
         for role in ("button", "link", "menuitem", "tab"):
             try:
                 loc = page.get_by_role(role, name=description, exact=exact)
                 if loc.count() > 0:
                     loc.first.scroll_into_view_if_needed()
                     loc.first.click()
-                    page.wait_for_load_state("domcontentloaded")
                     label = "exact" if exact else "partial"
-                    print(f"  --click-before: ✅ [role={role} {label}={description!r}]", flush=True)
-                    clicked = True
-                    break
+                    return f"role={role} {label}={description!r}"
             except Exception:
                 continue
 
-    # Tier 2: JS text / aria-label scan (same as do_click tier 3)
-    if not clicked:
-        try:
-            match = page.evaluate(
-                """(desc) => {
-                    const els = [...document.querySelectorAll(
-                        'button,a,[role=button],[role=menuitem],[role=tab]'
-                    )];
-                    const t = e => (e.textContent || '').trim();
-                    const el = els.find(e => t(e) === desc || e.getAttribute('aria-label') === desc)
-                              || els.find(e => t(e).startsWith(desc + ' ') || t(e).startsWith(desc + '\\n'));
-                    if (!el) return null;
-                    el.scrollIntoView({block: 'center'}); el.click();
-                    return (t(el) || el.getAttribute('aria-label') || '').slice(0, 60);
-                }""",
-                description,
-            )
-        except Exception:
-            match = None
+    try:
+        match = page.evaluate(
+            """(desc) => {
+                const els = [...document.querySelectorAll(
+                    'button,a,[role=button],[role=menuitem],[role=tab]'
+                )];
+                const t = e => (e.textContent || '').trim();
+                const el = els.find(e => t(e) === desc || e.getAttribute('aria-label') === desc)
+                          || els.find(e => t(e).startsWith(desc + ' ') || t(e).startsWith(desc + '\\n'));
+                if (!el) return null;
+                el.scrollIntoView({block: 'center'}); el.click();
+                return (t(el) || el.getAttribute('aria-label') || '').slice(0, 60);
+            }""",
+            description,
+        )
         if match:
-            page.wait_for_load_state("domcontentloaded")
-            print(f"  --click-before: ✅ [js→ {match!r}]", flush=True)
-            clicked = True
+            return f"js→ {match!r}"
+    except Exception:
+        pass
 
-    if not clicked:
+    return None
+
+
+def _click_before(page, description: str) -> bool:
+    """Click an element to open ephemeral UI state (dropdown, menu, accordion) before asserting.
+
+    Returns True to continue with the assertion, False if the click caused unintended
+    navigation (caller should return exit 2 / WRONG_PAGE in that case).
+    If the element is not found the function still returns True — the JS assertion
+    that follows will FAIL with the real reason, which is the correct logged outcome.
+    """
+    from urllib.parse import urlparse
+    url_before = page.url
+
+    label = _click_element(page, description)
+    if label:
+        _wait_animations(page)
+        print(f"  --click-before: ✅ [{label}]", flush=True)
+    else:
         print(
             f"  --click-before: ⚠️  '{description}' not found — "
             f"proceeding; assertion will report the actual failure",
@@ -241,24 +259,11 @@ def main() -> int:
             print(f"WRONG_PAGE: 404 or empty at {page.url}", flush=True)
             return 2
 
-        # 3. Click-before — open ephemeral UI state (dropdown/menu) before asserting.
-        #    Runs before the banner so the click is not confused by overlay injection.
-        if args.click_before:
-            if not _click_before(page, args.click_before):
-                print(f"WRONG_PAGE: --click-before caused navigation to {page.url}", flush=True)
-                return 2
-
-        # 3b. URL pre-check — abort if the current page is not what the assertion expects.
-        #     Catches wrong-tab and redirect scenarios before they produce a false verdict.
-        if args.expected_url_contains and args.expected_url_contains not in page.url:
-            print(
-                f"WRONG_PAGE: expected URL containing {args.expected_url_contains!r}, "
-                f"got {page.url!r}",
-                flush=True,
-            )
-            return 2
-
-        # 4. Show blue "Checking" banner (cosmetic — failures are silenced)
+        # 3. Inject the banner BEFORE click-before so the dropdown opens into an already-
+        #    stable DOM. If the banner were appended after the dropdown opens, its
+        #    document.body.appendChild call would fire a DOM mutation that triggers the
+        #    dropdown's close handler. Injecting first means only style-attribute changes
+        #    happen while the dropdown is open — those don't trigger childList observers.
         safe_what = args.what.replace("'", " ").replace('"', " ")[:120]
         try:
             page.evaluate(
@@ -275,6 +280,22 @@ def main() -> int:
         except Exception:
             pass
 
+        # 4. Click-before — open ephemeral UI state (dropdown/menu) before asserting.
+        #    Banner is already in the DOM, so no further appendChild mutations will fire.
+        if args.click_before:
+            if not _click_before(page, args.click_before):
+                print(f"WRONG_PAGE: --click-before caused navigation to {page.url}", flush=True)
+                return 2
+
+        # 4b. URL pre-check — abort if the current page is not what the assertion expects.
+        if args.expected_url_contains and args.expected_url_contains not in page.url:
+            print(
+                f"WRONG_PAGE: expected URL containing {args.expected_url_contains!r}, "
+                f"got {page.url!r}",
+                flush=True,
+            )
+            return 2
+
         # 4. Hide banner, run assertion (with optional retry), restore banner.
         #    Banner stays hidden for the full retry window — prevents its text from
         #    appearing in innerText checks inside the JS assertion.
@@ -288,7 +309,9 @@ def main() -> int:
             # On retry with --click-before: re-click so a toggled-closed container
             # gets toggled open again before the JS re-runs.
             if _attempt > 0 and args.click_before:
-                _click_before(page, args.click_before)
+                lbl = _click_element(page, args.click_before)
+                if lbl:
+                    _wait_animations(page)
             try:
                 raw = page.evaluate(args.js)  # direct Python return — no stdout parsing!
             except Exception as e:


### PR DESCRIPTION
## Summary

Follow-up to the `test-plan.ui-verify` skill. Four improvements to screenshot fidelity, assertion correctness, and code quality.

## Screenshot fixes

**Problem:** screenshots of dropdown/menu assertions showed a closed or mid-animation overlay, making it impossible to see what was actually verified.

- **Banner injected before `--click-before`** — the banner's `document.body.appendChild` was firing after the dropdown opened, triggering its mutation observer and closing it before the screenshot. Moving the injection earlier means the dropdown opens into an already-stable DOM.
- **Screenshot taken before `--selector` highlight** — the highlight step also uses `appendChild` (pointer label), closing open overlays. Screenshot now fires before any DOM injection.
- **Animation wait after `--click-before`** — uses `document.getAnimations()` to wait until non-infinite CSS animations complete, so the dropdown is fully rendered before screenshot. No hardcoded delay — adapts to actual animation duration.

## JS patterns and instructions

- `js-patterns.md`: new **visual-highlight-in-JS** pattern — apply `el.style.outline` as a side effect inside `--js`. Style changes don't trigger mutation observers, so the dropdown stays open; the cleanup step removes all `3px solid` outlines automatically.
- `instructions.md`: **inspect-first rule** — when asserting values that vary by environment (URL hostnames, cluster-specific IDs, resource names), always use `--inspect` to read the actual value first, then write the assertion from observation. Prevents the class of mistake where a route resource name is checked as a URL substring.

<img width="1920" height="937" alt="TC-UI-001-verify-rhoai-link-href-new-route" src="https://github.com/user-attachments/assets/3a9860a2-e7ec-44b2-a310-51ecd30770f4" />

## Refactor

- Extract `_wait_animations(page)` — eliminates the identical 7-line animation-wait block that appeared twice in `_click_before`.
- Extract `_click_element(page, description)` — the two-tier click logic (role-based + JS fallback) is now a shared helper; `_click_before` and the retry loop both use it instead of duplicating the logic.
- `github_utils._run` gains `**kw` to match `ui_prepare.run`.