### PR TITLE
Add plugin metadata and argument hints for autocomplete

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "test-plan",
+  "description": "End-to-end test planning workflow for RHOAI: generate test plans from strategies, create test cases, implement executable automation code, verify UI tests against live clusters via Playwright, publish to GitHub with PR creation, resolve review feedback, and score quality with automated rubrics using parallel sub-agent analysis",
+  "version": "0.2.0",
+  "author": {
+    "name": "Federico Mosca"
+  },
+  "repository": "https://github.com/fege/test-plan",
+  "homepage": "https://github.com/fege/test-plan",
+  "license": "Apache-2.0",
+  "keywords": [
+    "test-plan",
+    "test-cases",
+    "quality",
+    "strategy",
+    "review",
+    "scoring",
+    "rhoai",
+    "qa",
+    "automation",
+    "playwright",
+    "ui-testing"
+  ],
+  "category": "evaluation",
+  "dependencies": {
+    "python": ">=3.10",
+    "packages": ["pyyaml"]
+  }
+}

--- a/.claude/skills/test-plan.case-implement/SKILL.md
+++ b/.claude/skills/test-plan.case-implement/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: test-plan.case-implement
 description: Generate executable test automation code from test case specifications
+argument-hint: "[FEATURE_SOURCE] [--test-cases TC-ID,TC-ID] [--target-repo PATH]"
 user-invocable: true
 model: opus
 allowedTools:

--- a/.claude/skills/test-plan.create-cases/SKILL.md
+++ b/.claude/skills/test-plan.create-cases/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: test-plan.create-cases
 description: Generate individual test case files from an existing test plan. Use after /test-plan.create to produce TC-*.md files, INDEX.md, and update the test plan.
+argument-hint: "[FEATURE_SOURCE] [--output-dir PATH]"
 user-invocable: true
 model: opus
 allowed-tools: Read, Write, Edit, Bash, AskUserQuestion

--- a/.claude/skills/test-plan.create/SKILL.md
+++ b/.claude/skills/test-plan.create/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: test-plan.create
 description: Generate a test plan from a strategy (RHAISTRAT or RHOAIENG issue), with optional ADR for extra technical depth
+argument-hint: <JIRA_KEY> [ADR_FILE_PATH]
 user-invocable: true
 model: opus
 allowedTools:

--- a/.claude/skills/test-plan.publish/SKILL.md
+++ b/.claude/skills/test-plan.publish/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: test-plan.publish
 description: Publish test plan artifacts to GitHub — creates a branch, commits all artifacts, and opens a PR with optional reviewer assignment.
+argument-hint: "[FEATURE_SOURCE] [--repo owner/repo] [--reviewers user1,user2]"
 user-invocable: true
 model: sonnet
 allowedTools:

--- a/.claude/skills/test-plan.resolve-feedback/SKILL.md
+++ b/.claude/skills/test-plan.resolve-feedback/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: test-plan.resolve-feedback
 description: Assess PR review comments on a published test plan, let the user decide what to apply, make changes, and push updates to the same branch.
+argument-hint: <PR_URL>
 user-invocable: true
 model: sonnet
 allowedTools:

--- a/.claude/skills/test-plan.score/SKILL.md
+++ b/.claude/skills/test-plan.score/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: test-plan.score
 description: Score an existing test plan using the quality rubric without triggering auto-revision. Useful for evaluating test plans outside the generation pipeline.
+argument-hint: <feature_dir>
 user-invocable: true
 model: sonnet
 allowedTools:

--- a/.claude/skills/test-plan.ui-verify/SKILL.md
+++ b/.claude/skills/test-plan.ui-verify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: test-plan.ui-verify
 description: Browser-based UI test execution against live ODH/RHOAI clusters. Loads TCs from a GitHub PR or repo folder via ui_prepare.py, executes each via a persistent Playwright browser, and produces a visual HTML report with PASS/FAIL/BLOCKED/INCOMPLETE verdicts and screenshots.
+argument-hint: "(run after ui_prepare.py - no arguments)"
 user-invocable: true
 allowedTools:
   # Security note: ui_assert.py accepts --js with arbitrary JavaScript that

--- a/.claude/skills/test-plan.update/SKILL.md
+++ b/.claude/skills/test-plan.update/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: test-plan.update
 description: Update an existing test plan with new documentation (ADR, API specs, design docs). Re-analyzes, updates artifacts, bumps version, and optionally regenerates test cases.
+argument-hint: <SOURCE> <NEW_DOC_PATH> [<NEW_DOC_PATH>...]
 user-invocable: true
 model: opus
 allowedTools:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Test Plan
 
-Claude Code skills for generating test plans and test cases from RHOAI strategies.
+End-to-end test planning workflow for RHOAI: generate test plans from strategies, create test cases, implement executable automation code, verify UI tests against live clusters via Playwright, publish to GitHub with PR creation, resolve review feedback, and score quality with automated rubrics using parallel sub-agent analysis.
 
 ## Skills
 
@@ -12,7 +12,7 @@ Claude Code skills for generating test plans and test cases from RHOAI strategie
 | `/test-plan.create-cases` | Generate individual test case files from an existing test plan |
 | `/test-plan.update` | Update test plan with new docs (ADR, API specs), re-analyze, bump version |
 | `/test-plan.case-implement` | Generate executable test automation code from TC specifications with intelligent placement |
-| `/test-plan.ui-verify` | Verify UI test cases from a PR against a live ODH/RHOAI cluster via Playwright — see [README](.claude/skills/test-plan.ui-verify/README.md) |
+| `/test-plan.ui-verify` | Verify UI test cases from a PR against a live ODH/RHOAI cluster via Playwright; supports upgrade testing workflow — see [README](.claude/skills/test-plan.ui-verify/README.md) |
 | `/test-plan.publish` | Publish test plan artifacts to GitHub — branch, commit, and open a PR |
 | `/test-plan.resolve-feedback` | Assess PR review comments, let the user decide what to apply, and push updates |
 | `/test-plan.score` | Score an existing test plan using quality rubric (without auto-revision) |
@@ -77,6 +77,22 @@ uv pip install -e ".[dev]"
 Skills are available from `.claude/skills/` directory.
 
 **Note**: Skills use symlinks for shared utilities (`test-plan-common/scripts → ../../../scripts`). Both installation methods clone the full repository, so symlinks resolve correctly.
+
+## Plugin Metadata
+
+The plugin is defined in [.claude-plugin/plugin.json](.claude-plugin/plugin.json):
+- **Name**: test-plan
+- **Version**: 0.2.0
+- **Category**: evaluation
+- **Dependencies**: Python ≥3.10, pyyaml
+
+Each skill includes an `argument-hint` field in its frontmatter for autocomplete guidance:
+```bash
+/test-plan.create <JIRA_KEY> [ADR_FILE_PATH]
+/test-plan.create-cases [FEATURE_SOURCE] [--output-dir PATH]
+/test-plan.publish [FEATURE_SOURCE] [--repo owner/repo] [--reviewers user1,user2]
+# ... and 5 more user-invocable skills
+```
 
 ## Artifact Location
 
@@ -251,6 +267,9 @@ Contributors testing skills can use `--output-dir` to force creation in the curr
 ## Repository Structure
 
 ```
+.claude-plugin/
+└── plugin.json             # Plugin metadata (name, version, description, dependencies)
+
 .claude/skills/
 ├── test-plan.create/
 │   ├── SKILL.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "test-plan"
-version = "0.1.0"
+version = "0.2.0"
 description = "Claude Code skills for generating test plans and test cases"
 requires-python = ">=3.10"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -275,7 +275,7 @@ wheels = [
 
 [[package]]
 name = "test-plan"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
Add formal Claude Code plugin structure with autocomplete support:

Plugin Infrastructure:
- Add .claude-plugin/plugin.json with metadata (name, version, description, dependencies)
- Bump version from 0.1.0 to 0.2.0 across all files
- Update README with enhanced description and plugin metadata section