### PR TITLE
feat: support RHAIRFE Jira tickets for test plan creation

### DIFF
--- a/scripts/utils/schemas.py
+++ b/scripts/utils/schemas.py
@@ -45,7 +45,7 @@ SCHEMAS = {
         "source_key": {
             "type": "string",
             "required": True,
-            "pattern": r"^(RHAISTRAT|RHOAIENG)-\d+$",
+            "pattern": r"^(RHAISTRAT|RHOAIENG|RHAIRFE)-\d+$",
         },
         "source_type": {
             "type": "string",
@@ -96,7 +96,7 @@ SCHEMAS = {
         "source_key": {
             "type": "string",
             "required": True,
-            "pattern": r"^(RHAISTRAT|RHOAIENG)-\d+$",
+            "pattern": r"^(RHAISTRAT|RHOAIENG|RHAIRFE)-\d+$",
         },
         "priority": {
             "type": "string",
@@ -143,7 +143,7 @@ SCHEMAS = {
         "source_key": {
             "type": "string",
             "required": True,
-            "pattern": r"^(RHAISTRAT|RHOAIENG)-\d+$",
+            "pattern": r"^(RHAISTRAT|RHOAIENG|RHAIRFE)-\d+$",
         },
         "status": {
             "type": "string",
@@ -167,7 +167,7 @@ SCHEMAS = {
         "source_key": {
             "type": "string",
             "required": True,
-            "pattern": r"^(RHAISTRAT|RHOAIENG)-\d+$",
+            "pattern": r"^(RHAISTRAT|RHOAIENG|RHAIRFE)-\d+$",
         },
         "score": {
             "type": "int",

--- a/tests/unit/test_schema_validation.py
+++ b/tests/unit/test_schema_validation.py
@@ -53,14 +53,17 @@ class TestPlanSchemaValidation:
     """Test the test-plan schema validation rules."""
 
     @pytest.mark.parametrize("field_name,field_value,should_pass", [
-        # source_key validation (pattern: (RHAISTRAT|RHOAIENG)-\d+)
+        # source_key validation (pattern: (RHAISTRAT|RHOAIENG|RHAIRFE)-\d+)
         ("source_key", "RHAISTRAT-400", True),
         ("source_key", "RHAISTRAT-1", True),
         ("source_key", "RHOAIENG-48676", True),
         ("source_key", "RHOAIENG-1", True),
+        ("source_key", "RHAIRFE-1487", True),
+        ("source_key", "RHAIRFE-1", True),
         ("source_key", "INVALID-400", False),
         ("source_key", "RHAISTRAT400", False),
         ("source_key", "RHOAIENG400", False),
+        ("source_key", "RHAIRFE400", False),
         # version validation (pattern: X.Y.Z)
         ("version", "1.0.0", True),
         ("version", "10.20.30", True),


### PR DESCRIPTION
## Why
When running `/test-plan.create RHAIRFE-1487`, the schema validation failed 
because `RHAIRFE` was not in the list of allowed Jira issue key prefixes.

## Change
Added `RHAIRFE` to the pattern in `scripts/utils/schemas.py` alongside 
the existing `RHAISTRAT` and `RHOAIENG` prefixes.

## Test
- Verified `/test-plan.create RHAIRFE-1487` completes successfully with this change